### PR TITLE
Fix redirect in check-reallocarray

### DIFF
--- a/scripts/check-reallocarray.sh
+++ b/scripts/check-reallocarray.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 tfile=$(mktemp /tmp/test_reallocarray_XXXXXXXX.c)
 ofile=${tfile%.c}.o
@@ -13,6 +13,6 @@ int main(void)
 }
 EOL
 
-gcc $tfile -o $ofile >& /dev/null
+gcc $tfile -o $ofile >/dev/null 2>&1
 if [ $? -ne 0 ]; then echo "FAIL"; fi
 /bin/rm -f $tfile $ofile


### PR DESCRIPTION
Builds on debian stretch are failing due to:

../scripts/check-reallocarray.sh: 17: ../scripts/check-reallocarray.sh: Syntax error: Bad fd number

Fix the redirect of stdout and stderr.

Signed-off-by: David Ahern <dsahern@gmail.com>