### PR TITLE
add asm/errno.h to linux/err.h

### DIFF
--- a/include/linux/err.h
+++ b/include/linux/err.h
@@ -4,6 +4,7 @@
 #define __LINUX_ERR_H
 
 #include <linux/types.h>
+#include <asm/errno.h>
 
 #define MAX_ERRNO       4095
 


### PR DESCRIPTION
Otherwise, we will have the following compilation error:
```
  /home/yhs/work/bcc-new/src/cc/libbpf/src/bpf_prog_linfo.c:
      In function ‘dissect_jited_func’:
  /home/yhs/work/bcc-new/src/cc/libbpf/src/bpf_prog_linfo.c:88:10:
      error: ‘EINVAL’ undeclared (first use in this function)
    return -EINVAL;
```
The original linux/err.h at linux:tools/include directory
does include "asm/errno.h" as well.

Signed-off-by: Yonghong Song <yhs@fb.com>