### PR TITLE
Install bpf_common.h in install_uapi_headers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,8 @@ ifdef BUILD_SHARED
 endif
 
 HEADERS := bpf.h libbpf.h btf.h
-UAPI_HEADERS := $(addprefix $(TOPDIR)/include/uapi/linux/,bpf.h btf.h)
+UAPI_HEADERS := $(addprefix $(TOPDIR)/include/uapi/linux/,bpf.h bpf_common.h \
+	btf.h)
 
 INSTALL = install
 


### PR DESCRIPTION
bpf_common.h is hardly ever changed so it was not installed together
with other uapi headers. Some environments are still prefer to be
consistent and install all relevant uapi headers so add bpf_common.h to
uapi headers.

Signed-off-by: Andrey Ignatov <rdna@fb.com>