### PR TITLE
scripts: update sync script to do if_xdp.h syncing

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,7 @@ The following files will by sync'ed with bpf-next repo:
   include/uapi/linux/bpf.h <-> bpf-next/tools/include/uapi/linux/bpf.h
   include/uapi/linux/btf.h <-> bpf-next/tools/include/uapi/linux/btf.h
   include/uapi/linux/if_link.h <-> bpf-next/tools/include/uapi/linux/if_link.h
+  include/uapi/linux/if_xdp.h <-> bpf-next/tools/include/uapi/linux/if_xdp.h
   include/uapi/linux/netlink.h <-> bpf-next/tools/include/uapi/linux/netlink.h
   include/tools/libc_compat.h <-> bpf-next/tools/include/tools/libc_compat.h
 

--- a/scripts/sync-kernel.sh
+++ b/scripts/sync-kernel.sh
@@ -71,12 +71,13 @@ for LIBBPF_NEW_COMMIT in ${LIBBPF_NEW_COMMITS}; do
 	git cherry-pick ${LIBBPF_NEW_COMMIT}
 done
 
-LIBBPF_TREE_FILTER='												      \
-    mkdir -p __libbpf/include/uapi/linux __libbpf/include/tools &&						      \
-    git mv -kf tools/lib/bpf __libbpf/src &&									      \
-    git mv -kf tools/include/uapi/linux/{bpf_common.h,bpf.h,btf.h,if_link.h,netlink.h} __libbpf/include/uapi/linux && \
-    git mv -kf tools/include/tools/libc_compat.h __libbpf/include/tools &&					      \
-    git rm --ignore-unmatch -f __libbpf/src/{Makefile,Build,test_libbpf.cpp,.gitignore}				      \
+LIBBPF_TREE_FILTER='												\
+    mkdir -p __libbpf/include/uapi/linux __libbpf/include/tools &&						\
+    git mv -kf tools/lib/bpf __libbpf/src &&									\
+    git mv -kf tools/include/uapi/linux/{bpf_common.h,bpf.h,btf.h,if_link.h,if_xdp.h,netlink.h}			\
+	       __libbpf/include/uapi/linux &&									\
+    git mv -kf tools/include/tools/libc_compat.h __libbpf/include/tools &&					\
+    git rm --ignore-unmatch -f __libbpf/src/{Makefile,Build,test_libbpf.cpp,.gitignore}				\
 '
 # Move all libbpf files into __libbpf directory.
 git filter-branch --prune-empty -f --tree-filter "${LIBBPF_TREE_FILTER}" ${SQUASH_TIP_TAG} ${SQUASH_BASE_TAG}
@@ -117,7 +118,7 @@ git commit --file=-
 echo "SUCCESS! ${COMMIT_CNT} commits synced."
 
 echo "Verifying Linux's and Github's libbpf state"
-LIBBPF_VIEW_PATHS=(src include/uapi/linux/{bpf_common.h,bpf.h,btf.h,if_link.h,netlink.h} include/tools/libc_compat.h)
+LIBBPF_VIEW_PATHS=(src include/uapi/linux/{bpf_common.h,bpf.h,btf.h,if_link.h,if_xdp.h,netlink.h} include/tools/libc_compat.h)
 LIBBPF_VIEW_EXCLUDE_REGEX='^src/(Makefile|Build|test_libbpf.cpp|\.gitignore)$'
 
 cd ${WORKDIR} && cd ${LINUX_REPO}


### PR DESCRIPTION
With xsk.{o,h} changes we started including Linux UAPI's if_xdp.h
header. We need to sync it along the other UAPI headers.

Also updated README to reflect this.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>