### PR TITLE
build shared library by default and use pkg-config to get libelf flags

### DIFF
--- a/README
+++ b/README
@@ -19,14 +19,13 @@ successful.
 
 Build
 =====
-
-To build static library libbpf.a:
+To build both static libbpf.a and shared libbpf.so:
   cd src
   make
 
-To build both static libbpf.a and shared libbpf.so libraries in directory
+To build only static libbpf.a library in directory
 build/ and install them together with libbpf headers in a staging directory
 root/:
   cd src
   mkdir build root
-  BUILD_SHARED=y OBJDIR=build DESTDIR=root make install
+  BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=root make install

--- a/README
+++ b/README
@@ -19,6 +19,13 @@ successful.
 
 Build
 =====
+libelf is an internal dependency of libbpf and thus it is required to link
+against and must be installed on the system for applications to work.
+pkg-config is used by default to find libelf, and the program called can be
+overridden with PKG_CONFIG.
+If using pkg-config at build time is not desired, it can be disabled by setting
+NO_PKG_CONFIG=1 when calling make.
+
 To build both static libbpf.a and shared libbpf.so:
   cd src
   make
@@ -29,3 +36,10 @@ root/:
   cd src
   mkdir build root
   BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=root make install
+
+To build both static libbpf.a and shared libbpf.so against a custom libelf
+dependency installed in /build/root/ and install them together with libbpf
+headers in a build directory /build/root/:
+
+  cd src
+  PKG_CONFIG_PATH=/build/root/lib64/pkgconfig DESTDIR=/build/root make install

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,14 @@ endif
 
 CFLAGS ?= -g -O2 -Werror -Wall
 ALL_CFLAGS += $(CFLAGS)
+ALL_LDFLAGS += $(LDFLAGS)
+ifdef NO_PKG_CONFIG
+	ALL_LDFLAGS += -lelf
+else
+	PKG_CONFIG ?= pkg-config
+	ALL_CFLAGS += $(shell $(PKG_CONFIG) --cflags libelf)
+	ALL_LDFLAGS += $(shell $(PKG_CONFIG) --libs libelf)
+endif
 
 OBJDIR ?= .
 
@@ -54,7 +62,7 @@ $(OBJDIR)/libbpf.a: $(OBJS)
 	$(AR) rcs $@ $^
 
 $(OBJDIR)/libbpf.so: $(OBJS)
-	$(CC) -shared $(LDFLAGS) $^ -o $@
+	$(CC) -shared $(ALL_LDFLAGS) $^ -o $@
 
 $(OBJDIR)/libbpf.pc:
 	sed -e "s|@PREFIX@|$(PREFIX)|" \

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ ifneq ($(FEATURE_REALLOCARRAY),)
 	ALL_CFLAGS += -DCOMPAT_NEED_REALLOCARRAY
 endif
 
-ifdef BUILD_SHARED
+ifndef BUILD_STATIC_ONLY
 	ALL_CFLAGS += -fPIC -fvisibility=hidden
 endif
 
@@ -23,7 +23,7 @@ OBJS := $(addprefix $(OBJDIR)/,bpf.o btf.o libbpf.o libbpf_errno.o netlink.o \
 	nlattr.o str_error.o libbpf_probes.o bpf_prog_linfo.o xsk.o)
 
 LIBS := $(OBJDIR)/libbpf.a
-ifdef BUILD_SHARED
+ifndef BUILD_STATIC_ONLY
 	LIBS += $(OBJDIR)/libbpf.so
 endif
 


### PR DESCRIPTION
When reading this, please consider the point of view of ommon users or distribution packagers, and the most common use cases.

What is good for those use cases:

- default behaviour is the expected behaviour
- use standard commands and tools
- not having to read into makefiles to find out special variables, special flags or special sauces of any kind
- things just work as expected

The expected behaviour is to get out of the box something that works and can be used immediately, which is usually a shared library linked against its dependencies found automatically.
The expected behaviour is also to work seamlessly with existing build systems, toolchains and packaging tools.

In lieu of that view, these 2 commits switch around the makefile behaviour and build the shared lib by default (adding a flag to turn it off), and use pkg-config _if available_ to find the dependency libelf and to link against it (and fall back to just -lelf if not).

libbpf uses libelf symbols internally, so it depends on it and needs to link against it or applications will not work. It is the job of each project to correctly link against all their internal dependencies.

Upstream this was fixed by linking directory to libelf:

https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git/commit/?id=89dedaef49d36adc2bb5e7e4c38b52fa3013c7c8

This is compatible with both implementations of libelf - elfutils (used everywhere nowadays) and the old, unmaintained libelf. They both ship a libelf.pc and libelf.so.

pkg-config is the normal and most common way of handling build environment changes - one defines a preferred PKG_CONFIG_PATH environment variable that drives pkg-config toward one installation or the other, deterministically and most importantly without any special sauce specific to this or that project. It makes things like cross compilation saner.

Eg:

```
$ cd /tmp/libelf-0.8.13
$ ./configure --prefix=/tmp/elf; make; make install
loading cache ./config.cache
<...>
$ cd ~/git/libbpf/src
$ PKG_CONFIG_PATH=/tmp/elf/lib/pkgconfig make
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c bpf.c -o bpf.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c btf.c -o btf.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c libbpf.c -o libbpf.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c libbpf_errno.c -o libbpf_errno.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c netlink.c -o netlink.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c nlattr.c -o nlattr.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c str_error.c -o str_error.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c libbpf_probes.c -o libbpf_probes.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c bpf_prog_linfo.c -o bpf_prog_linfo.o
ccache gcc -I. -I../include -I../include/uapi -fPIC -fvisibility=hidden -g -O2 -Werror -Wall -I/tmp/elf/include/libelf -I/tmp/elf/include  -c xsk.c -o xsk.o
ar rcs libbpf.a bpf.o btf.o libbpf.o libbpf_errno.o netlink.o nlattr.o str_error.o libbpf_probes.o bpf_prog_linfo.o xsk.o
ccache gcc -shared -L/tmp/elf/lib -lelf bpf.o btf.o libbpf.o libbpf_errno.o netlink.o nlattr.o str_error.o libbpf_probes.o bpf_prog_linfo.o xsk.o -o libbpf.so
sed -e "s|@PREFIX@|/usr|" \
	-e "s|@LIBDIR@|/usr/lib64|" \
	-e "s|@VERSION@||" \
	< libbpf.pc.template > libbpf.pc
$ ldd libbpf.so 
	linux-vdso.so.1 (0x00007fff1958e000)
	libelf.so.0 => not found
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa6ca2d7000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fa6ca4d9000)
$ LD_LIBRARY_PATH=/tmp/elf/lib/ ldd libbpf.so 
	linux-vdso.so.1 (0x00007ffcf57d8000)
	libelf.so.0 => /tmp/elf/lib/libelf.so.0 (0x00007fc7a5497000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc7a52af000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc7a54c8000)
```

This makes the build work out of the box in the most common cases as expected by all distro users and packagers, while still allowing a standard and unspecific way of overriding. No special sauces required, everybody's happy!