### PR TITLE
Fix libbpf.pc target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ HEADERS := bpf.h libbpf.h btf.h
 UAPI_HEADERS := $(addprefix $(TOPDIR)/include/uapi/linux/,bpf.h bpf_common.h \
 	btf.h)
 
-PC_FILE := libbpf.pc
+PC_FILE := $(OBJDIR)/libbpf.pc
 
 INSTALL = install
 


### PR DESCRIPTION
OBJDIR was not specified for libbpf.pc. It works by default since
default value of OBJDIR is current directory, but breaks as soon as
OBJDIR is set to some other directory:
```
  % OBJDIR=build DESTDIR=root make install
  ...
  ar rcs build/libbpf.a build/bpf.o build/btf.o build/libbpf.o
  build/libbpf_errno.o build/netlink.o build/nlattr.o build/str_error.o
  build/libbpf_probes.o build/bpf_prog_linfo.o build/xsk.o
  cc -shared  -lelf   build/bpf.o build/btf.o build/libbpf.o build/libbpf_errno.o
  build/netlink.o build/nlattr.o build/str_error.o build/libbpf_probes.o
  build/bpf_prog_linfo.o build/xsk.o -o build/libbpf.so
  make: *** No rule to make target `libbpf.pc', needed by `all'.  Stop.
```
Fix it.

Signed-off-by: Andrey Ignatov <rdna@fb.com>