### PR TITLE
add meson.build to integrate libbpf as a subproject of a project built by Meson

### DIFF
--- a/README
+++ b/README
@@ -43,3 +43,20 @@ headers in a build directory /build/root/:
 
   cd src
   PKG_CONFIG_PATH=/build/root/lib64/pkgconfig DESTDIR=/build/root make install
+
+To integrate libbpf into a project which uses Meson building system define
+[wrap-git] file in `subprojects` folder.
+To add libbpf dependency to the parent parent project, e.g. for
+libbpf_static_dep:
+
+   libbpf_obj = subproject('libbpf', required : true)
+   libbpf_static_dep = libbpf_proj.get_variable('libbpf_static_dep')
+
+To validate changes to meson.build
+
+   python3 meson.py build
+   ninja -C build/
+
+To install headers, libs and pkgconfig
+   cd build
+   ninja install

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: LGPL-2.1 OR BSD-2-Clause
+project('libbpf', 'c',
+        version : '0.0.3',
+        license : 'LGPL-2.1 OR BSD-2-Clause',
+        default_options : [
+                'prefix=/usr',
+        ],
+        meson_version : '>= 0.46',
+        )
+
+patchlevel = meson.project_version().split('.')[1]
+
+libbpf_source_dir = './'
+
+libbpf_sources = files(run_command('find',
+        [
+        '@0@/src'.format(libbpf_source_dir),
+        '-type',
+        'f',
+        '-name',
+        '*.[h|c]']).stdout().split())
+
+libbpf_headers = files(
+        join_paths(libbpf_source_dir, 'src/bpf.h'),
+        join_paths(libbpf_source_dir, 'src/btf.h'),
+        join_paths(libbpf_source_dir, 'src/libbpf.h'))
+
+feature_rellocarray = run_command(join_paths(libbpf_source_dir, 'scripts/check-reallocarray.sh'))
+
+libbpf_c_args = ['-g',
+                '-O2',
+                '-Werror',
+                '-Wall',
+]
+
+if feature_rellocarray.stdout().strip() != ''
+        libbpf_c_args += '-DCOMPAT_NEED_REALLOCARRAY'
+endif
+
+# bpf_includes are required to include bpf.h, btf.h, libbpf.h
+bpf_includes = include_directories(
+        join_paths(libbpf_source_dir, 'src'))
+
+libbpf_includes = include_directories(
+        join_paths(libbpf_source_dir, 'include'),
+        join_paths(libbpf_source_dir, 'include/uapi'))
+
+libelf = dependency('libelf')
+libelf = dependency('libelf', required: false)
+if not libelf.found()
+        libelf = cc.find_library('elf', required: true)
+endif
+
+deps = [libelf]
+
+libbpf_static = static_library(
+        'bpf',
+        libbpf_sources,
+        c_args : libbpf_c_args,
+        dependencies : deps,
+        include_directories : libbpf_includes,
+        install : true)
+
+libbpf_static_dep = declare_dependency(link_with : libbpf_static)
+
+libbpf_map_source_path = join_paths(libbpf_source_dir, 'src/libbpf.map')
+libbpf_map_abs_path = join_paths(meson.current_source_dir(), libbpf_map_source_path)
+
+libbpf_c_args += ['-fPIC', '-fvisibility=hidden']
+
+libbpf_link_args = ['-Wl,--version-script=@0@'.format(libbpf_map_abs_path)]
+
+libbpf_shared = shared_library(
+        'bpf',
+        libbpf_sources,
+        c_args : libbpf_c_args,
+        dependencies : deps,
+        include_directories : libbpf_includes,
+        install : true,
+        link_args : libbpf_link_args,
+        link_depends : libbpf_map_source_path,
+        soversion : patchlevel,
+        version : meson.project_version())
+
+libbpf_shared_dep = declare_dependency(link_with : libbpf_shared)
+
+install_headers(libbpf_headers, subdir : 'bpf')
+
+pkg = import('pkgconfig')
+pkg.generate(
+        name: meson.project_name(),
+        version: meson.project_version(),
+        libraries: libbpf_shared,
+        requires_private: ['libelf'],
+        description: '''BPF library''')


### PR DESCRIPTION
Make it possible to include libbpf into projects built by Meson build system as
a subproject. This is the case e.g. for systemd.

meson.build declares dependencies which may be used in parent projects:
`libbpf_static_dep` for static library
`libbpf_shared_dep` for shared library
`bpf_includes` provides the location of bpf.h, btf.h and libbpf.h

Parent projects need to introduce git wrap to build libbpf:
https://github.com/mesonbuild/meson/blob/master/docs/markdown/Wrap-dependency-system-manual.md#wrap-git

An alternative approach is applying a patch with meson.build for libbpf while
building a parent project:
https://github.com/mesonbuild/meson/blob/master/docs/markdown/Wrap-dependency-system-manual.md#wrap-file
Imo it's less transparent and would add more headache.

Note that this commit provides only the essentials for adding libbpf as a
subproject, it does not install headers or libraries.

meson.build is placed in the source root because that's how Meson expects it to
be placed.

The related discussion is in https://github.com/systemd/systemd/pull/12151