### PR TITLE
Introduce Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,91 @@
+sudo: required
+dist: xenial
+services:
+    - docker
+
+env:
+    global:
+        - AUTHOR_EMAIL="$(git log -1 $TRAVIS_COMMIT --pretty=\"%aE\")"
+        - CI_MANAGERS="$TRAVIS_BUILD_DIR/travis-ci/managers"
+        - REPO_ROOT="$TRAVIS_BUILD_DIR"
+
+jobs:
+    include:
+        - stage: Build & test
+          name: Debian Testing
+          language: bash
+          env:
+              - DEBIAN_RELEASE="testing"
+              - CONT_NAME="libbpf-debian-$DEBIAN_RELEASE"
+              - DOCKER_EXEC="docker exec -ti $CONT_NAME"
+          before_install:
+              - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+              - docker --version
+          install:
+              - $CI_MANAGERS/debian.sh SETUP
+          script:
+              - set -e
+              - $CI_MANAGERS/debian.sh RUN
+              - set +e
+          after_script:
+              - $CI_MANAGERS/debian.sh CLEANUP
+
+        - name: Debian Testing (ASan+UBSan)
+          language: bash
+          env:
+              - DEBIAN_RELEASE="testing"
+              - CONT_NAME="libbpf-debian-$DEBIAN_RELEASE"
+              - DOCKER_EXEC="docker exec -ti $CONT_NAME"
+          before_install:
+              - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+              - docker --version
+          install:
+              - $CI_MANAGERS/debian.sh SETUP
+          script:
+              - set -e
+              - $CI_MANAGERS/debian.sh RUN_ASAN
+              - set +e
+          after_script:
+              - $CI_MANAGERS/debian.sh CLEANUP
+
+        - name: Debian Testing (clang)
+          language: bash
+          env:
+              - DEBIAN_RELEASE="testing"
+              - CONT_NAME="libbpf-debian-$DEBIAN_RELEASE"
+              - DOCKER_EXEC="docker exec -ti $CONT_NAME"
+          before_install:
+              - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+              - docker --version
+          install:
+              - $CI_MANAGERS/debian.sh SETUP
+          script:
+              - set -e
+              - $CI_MANAGERS/debian.sh RUN_CLANG
+              - set +e
+          after_script:
+              - $CI_MANAGERS/debian.sh CLEANUP
+
+        - name: Debian Testing (clang ASan+UBSan)
+          language: bash
+          env:
+              - DEBIAN_RELEASE="testing"
+              - CONT_NAME="libbpf-debian-$DEBIAN_RELEASE"
+              - DOCKER_EXEC="docker exec -ti $CONT_NAME"
+          before_install:
+              - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+              - docker --version
+          install:
+              - $CI_MANAGERS/debian.sh SETUP
+          script:
+              - set -e
+              - $CI_MANAGERS/debian.sh RUN_CLANG_ASAN
+              - set +e
+          after_script:
+              - $CI_MANAGERS/debian.sh CLEANUP
+        - name: Ubuntu Xenial
+          language: bash
+          script:
+              - set -e
+              - sudo $CI_MANAGERS/xenial.sh
+              - set +e

--- a/travis-ci/managers/debian.sh
+++ b/travis-ci/managers/debian.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+PHASES=(${@:-SETUP RUN RUN_ASAN CLEANUP})
+DEBIAN_RELEASE="${DEBIAN_RELEASE:-testing}"
+CONT_NAME="${CONT_NAME:-debian-$DEBIAN_RELEASE-$RANDOM}"
+DOCKER_EXEC="${DOCKER_EXEC:-docker exec -it $CONT_NAME}"
+DOCKER_RUN="${DOCKER_RUN:-docker run}"
+REPO_ROOT="${REPO_ROOT:-$PWD}"
+ADDITIONAL_DEPS=(clang)
+
+function info() {
+    echo -e "\033[33;1m$1\033[0m"
+}
+
+set -e
+
+source "$(dirname $0)/travis_wait.bash"
+
+for phase in "${PHASES[@]}"; do
+    case $phase in
+        SETUP)
+            info "Setup phase"
+            info "Using Debian $DEBIAN_RELEASE"
+	    docker pull debian:$DEBIAN_RELEASE
+            info "Starting container $CONT_NAME"
+            $DOCKER_RUN -v $REPO_ROOT:/build:rw \
+                        -w /build --privileged=true --name $CONT_NAME \
+			-dit --net=host debian:$DEBIAN_RELEASE /bin/bash
+            $DOCKER_EXEC bash -c "echo deb-src http://deb.debian.org/debian $DEBIAN_RELEASE main >>/etc/apt/sources.list"
+            $DOCKER_EXEC apt-get -y update
+            $DOCKER_EXEC apt-get -y build-dep libelf-dev
+            $DOCKER_EXEC apt-get -y install libelf-dev
+            $DOCKER_EXEC apt-get -y install "${ADDITIONAL_DEPS[@]}"
+            ;;
+        RUN|RUN_CLANG)
+            if [[ "$phase" = "RUN_CLANG" ]]; then
+                ENV_VARS="-e CC=clang -e CXX=clang++"
+            fi
+            docker exec $ENV_VARS -it $CONT_NAME mkdir build
+            $DOCKER_EXEC make CFLAGS='-Werror' -C ./src -B OBJDIR=../build
+            $DOCKER_EXEC rm -rf build
+            ;;
+        RUN_ASAN|RUN_CLANG_ASAN)
+            if [[ "$phase" = "RUN_CLANG_ASAN" ]]; then
+                ENV_VARS="-e CC=clang -e CXX=clang++"
+            fi
+            docker exec $ENV_VARS -it $CONT_NAME mkdir build
+            $DOCKER_EXEC make CFLAGS='-Werror -Db_sanitize=address,undefined' -C ./src -B OBJDIR=../build
+            $DOCKER_EXEC rm -rf build
+            ;;
+        CLEANUP)
+            info "Cleanup phase"
+            docker stop $CONT_NAME
+            docker rm -f $CONT_NAME
+            ;;
+        *)
+            echo >&2 "Unknown phase '$phase'"
+            exit 1
+    esac
+done

--- a/travis-ci/managers/travis_wait.bash
+++ b/travis-ci/managers/travis_wait.bash
@@ -1,0 +1,61 @@
+# This was borrowed from https://github.com/travis-ci/travis-build/tree/master/lib/travis/build/bash
+# to get around https://github.com/travis-ci/travis-ci/issues/9979. It should probably be removed
+# as soon as Travis CI has started to provide an easy way to export the functions to bash scripts.
+
+travis_jigger() {
+  local cmd_pid="${1}"
+  shift
+  local timeout="${1}"
+  shift
+  local count=0
+
+  echo -e "\\n"
+
+  while [[ "${count}" -lt "${timeout}" ]]; do
+    count="$((count + 1))"
+    echo -ne "Still running (${count} of ${timeout}): ${*}\\r"
+    sleep 60
+  done
+
+  echo -e "\\n${ANSI_RED}Timeout (${timeout} minutes) reached. Terminating \"${*}\"${ANSI_RESET}\\n"
+  kill -9 "${cmd_pid}"
+}
+
+travis_wait() {
+  local timeout="${1}"
+
+  if [[ "${timeout}" =~ ^[0-9]+$ ]]; then
+    shift
+  else
+    timeout=20
+  fi
+
+  local cmd=("${@}")
+  local log_file="travis_wait_${$}.log"
+
+  "${cmd[@]}" &>"${log_file}" &
+  local cmd_pid="${!}"
+
+  travis_jigger "${!}" "${timeout}" "${cmd[@]}" &
+  local jigger_pid="${!}"
+  local result
+
+  {
+    set +e
+    wait "${cmd_pid}" 2>/dev/null
+    result="${?}"
+    ps -p"${jigger_pid}" &>/dev/null && kill "${jigger_pid}"
+    set -e
+  }
+
+  if [[ "${result}" -eq 0 ]]; then
+    echo -e "\\n${ANSI_GREEN}The command ${cmd[*]} exited with ${result}.${ANSI_RESET}"
+  else
+    echo -e "\\n${ANSI_RED}The command ${cmd[*]} exited with ${result}.${ANSI_RESET}"
+  fi
+
+  echo -e "\\n${ANSI_GREEN}Log:${ANSI_RESET}\\n"
+  cat "${log_file}"
+
+  return "${result}"
+}

--- a/travis-ci/managers/xenial.sh
+++ b/travis-ci/managers/xenial.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -x
+
+apt-get update
+apt-get -y build-dep libelf-dev
+apt-get install -y libelf-dev
+
+source "$(dirname $0)/travis_wait.bash"
+
+cd $REPO_ROOT
+
+mkdir build
+make CFLAGS='-Werror -Db_sanitize=address,undefined' -C ./src -B OBJDIR=../build
+rm -rf build


### PR DESCRIPTION
In order to `libbpf` to be used in systemd some testing is required, see related
discussions in https://github.com/systemd/systemd/pull/12151 and
https://github.com/libbpf/libbpf/pull/29
Having CI will help track issues like https://github.com/libbpf/libbpf/issues/27 and https://github.com/libbpf/libbpf/issues/28
Tests introduced here mirror the tests of systemd:
For Debian: use `docker` virtualization, build with gcc, gcc + asan, clang, clang + asan.
Fror Ubuntu Xenial: build with gcc.

Differences:
For `libbpf` only `libelf` and its dependencies are installed.
Instead of Meson build system `make` is used, so `make` remains the preferred
method of building and `meson.build` doesn't get rooted in `libbpf`.

`travis_wait.bash` is kept as a workaround for
https://github.com/travis-ci/travis-ci/issues/9979

An example of testing UI: https://travis-ci.org/wat-ze-hex/libbpf