### PR TITLE
Support less common environments like Alpine (musl)

### DIFF
--- a/include/linux/types.h
+++ b/include/linux/types.h
@@ -7,6 +7,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <linux/stddef.h>
+
 #include <asm/types.h>
 #include <asm/posix_types.h>
 


### PR DESCRIPTION
This fixes the build in environments such as Alpine Linux (musl).

/cc @yonghong-song per discussion in https://github.com/iovisor/bcc/issues/2338

----

For reference, this was the build error:

```
# make
[...]
cc -I. -I../include -I../include/uapi -DCOMPAT_NEED_REALLOCARRAY -g -O2 -Werror -Wall -c libbpf.c -o libbpf.o
In file included from /usr/include/linux/byteorder/little_endian.h:13,
                 from /usr/include/asm/byteorder.h:5,
                 from /usr/include/linux/perf_event.h:20,
                 from libbpf.c:32:
/usr/include/linux/swab.h:161:8: error: unknown type name '__always_inline'
 static __always_inline __u16 __swab16p(const __u16 *p)
        ^~~~~~~~~~~~~~~
/usr/include/linux/swab.h:161:30: error: expected '=', ',', ';', 'asm' or '__attribute__' before '__swab16p'
 static __always_inline __u16 __swab16p(const __u16 *p)
                              ^~~~~~~~~
/usr/include/linux/swab.h:174:8: error: unknown type name '__always_inline'
 static __always_inline __u32 __swab32p(const __u32 *p)
        ^~~~~~~~~~~~~~~
/usr/include/linux/swab.h:174:30: error: expected '=', ',', ';', 'asm' or '__attribute__' before '__swab32p'
 static __always_inline __u32 __swab32p(const __u32 *p)
                              ^~~~~~~~~
/usr/include/linux/swab.h:187:8: error: unknown type name '__always_inline'
 static __always_inline __u64 __swab64p(const __u64 *p)
        ^~~~~~~~~~~~~~~
/usr/include/linux/swab.h:187:30: error: expected '=', ',', ';', 'asm' or '__attribute__' before '__swab64p'
 static __always_inline __u64 __swab64p(const __u64 *p)
                              ^~~~~~~~~
/usr/include/linux/swab.h:242:23: error: expected ';' before 'void'
 static __always_inline void __swab32s(__u32 *p)
                       ^~~~~
                       ;
/usr/include/linux/swab.h:255:23: error: expected ';' before 'void'
 static __always_inline void __swab64s(__u64 *p)
                       ^~~~~
                       ;
```