### PR TITLE
filter.h: add missing BPF raw instruction macros

### DIFF
--- a/include/linux/filter.h
+++ b/include/linux/filter.h
@@ -53,6 +53,14 @@
 		.off   = OFF,					\
 		.imm   = 0 })
 
+#define BPF_ST_MEM(SIZE, DST, OFF, IMM)				\
+	((struct bpf_insn) {					\
+		.code  = BPF_ST | BPF_SIZE(SIZE) | BPF_MEM,	\
+		.dst_reg = DST,					\
+		.src_reg = 0,					\
+		.off   = OFF,					\
+		.imm   = IMM })
+
 #define BPF_MOV64_REG(DST, SRC)					\
 	((struct bpf_insn) {					\
 		.code  = BPF_ALU64 | BPF_MOV | BPF_X,		\
@@ -69,22 +77,27 @@
 		.off   = 0,					\
 		.imm   = IMM })
 
-#define BPF_LD_IMM64_RAW(DST, SRC, IMM)				\
+#define BPF_LD_IMM64_RAW_FULL(DST, SRC, OFF1, OFF2, IMM1, IMM2)	\
 	((struct bpf_insn) {					\
 		.code = BPF_LD | BPF_DW | BPF_IMM,		\
 		.dst_reg = DST,					\
 		.src_reg = SRC,					\
-		.off   = 0,					\
-		.imm   = (__u32) (IMM) }),			\
+		.off   = OFF1,					\
+		.imm   = IMM1 }),			\
 	((struct bpf_insn) {					\
 		.code  = 0,					\
 		.dst_reg = 0,					\
 		.src_reg = 0,					\
-		.off   = 0,					\
-		.imm   = ((__u64) (IMM)) >> 32 })
+		.off   = OFF2,					\
+		.imm   = IMM2 })
 
 #define BPF_LD_MAP_FD(DST, MAP_FD)				\
-	BPF_LD_IMM64_RAW(DST, BPF_PSEUDO_MAP_FD, MAP_FD)
+	BPF_LD_IMM64_RAW_FULL(DST, BPF_PSEUDO_MAP_FD, 0, 0,	\
+			      MAP_FD, 0)
+
+#define BPF_LD_MAP_VALUE(DST, MAP_FD, VALUE_OFF)		\
+	BPF_LD_IMM64_RAW_FULL(DST, BPF_PSEUDO_MAP_FD, 0, 0,	\
+			      MAP_FD, VALUE_OFF)
 
 #define BPF_JMP_IMM(OP, DST, IMM, OFF)				\
 	((struct bpf_insn) {					\


### PR DESCRIPTION
These are used in some of the new commits from bpf-next.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>