### PR TITLE
linux/err.h: add PTR_ERR_OR_ZERO

### DIFF
--- a/include/linux/err.h
+++ b/include/linux/err.h
@@ -30,4 +30,9 @@ static inline bool IS_ERR_OR_NULL(const void *ptr)
 	return (!ptr) || IS_ERR_VALUE((unsigned long)ptr);
 }
 
+static inline long PTR_ERR_OR_ZERO(const void *ptr)
+{
+	return IS_ERR(ptr) ? PTR_ERR(ptr) : 0;
+}
+
 #endif

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,4 @@
 *.o
 *.a
+/libbpf.pc
+/libbpf.so*


### PR DESCRIPTION
Add missing PTR_ERR_OR_ZERO implementation. Also add a bunch of
generated files to .gitignore.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>