### PR TITLE
Add libbpf.spec for RPM packaging

### DIFF
--- a/libbpf.spec
+++ b/libbpf.spec
@@ -1,0 +1,54 @@
+Name:           libbpf
+Version:        0.0.4
+Release:        1%{?dist}
+Summary:        Libbpf library
+Group:          Development/System
+Packager:       Julia Kartseva <hex@fb.com>
+
+License:        GPL-2.1 OR BSD-2-Clause
+URL:            https://github.com/libbpf/libbpf
+Source:         libbpf-%{version}-%{release}.tar.gz
+BuildRequires:  elfutils-libelf-devel elfutils-devel
+
+%description
+A mirror of bpf-next linux tree bpf-next/tools/lib/bpf directory plus its
+  supporting header files. The version of the package reflects the version of
+  ABI.
+
+%package devel
+Summary: Development files for %{name}
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+The %{name}-devel package contains libraries header files for
+developing applications that use %{name}
+
+%prep
+%autosetup
+
+%build
+%make_build -C ./src DESTDIR=%{buildroot} OBJDIR=%{_builddir}
+
+%install
+%make_install -C ./src DESTDIR=%{buildroot} OBJDIR=%{_builddir}
+
+%clean
+rm -rf "%{buildroot}"
+
+%files
+%attr(0755,-,-) %{_libdir}/libbpf.so.%{version}
+%{_libdir}/libbpf.so.0
+%{_libdir}/libbpf.so
+
+%files devel
+%attr(0644,-,-) %{_includedir}/bpf/bpf.h
+%attr(0644,-,-) %{_includedir}/bpf/btf.h
+%attr(0644,-,-) %{_includedir}/bpf/libbpf.h
+%attr(0644,_,_) %{_includedir}/bpf/libbpf_util.h
+%attr(0644,_,_) %{_includedir}/bpf/xsk.h
+%attr(0644,-,-) %{_libdir}/libbpf.a
+%attr(0644,-,-) %{_libdir}/pkgconfig/libbpf.pc
+
+%changelog
+* Thu Aug 8 2019 Julia Kartseva <hex@fb.com> - 0.0.4-1%{?dist}
+- Initial release

--- a/libbpf.spec
+++ b/libbpf.spec
@@ -1,5 +1,5 @@
 Name:           libbpf
-Version:        0.0.4
+Version:        0.0.5
 Release:        1%{?dist}
 Summary:        Libbpf library
 Group:          Development/System
@@ -50,5 +50,5 @@ rm -rf "%{buildroot}"
 %attr(0644,-,-) %{_libdir}/pkgconfig/libbpf.pc
 
 %changelog
-* Thu Aug 8 2019 Julia Kartseva <hex@fb.com> - 0.0.4-1%{?dist}
+* Thu Aug 22 2019 Julia Kartseva <hex@fb.com> - 0.0.5-1%{?dist}
 - Initial release


### PR DESCRIPTION
A sample libbpf.spec to initiate a process of `libbpf` publishing to
distributives.

Creating a PR as a possible place to continue the discussion started in [[1]](https://lists.iovisor.org/g/iovisor-dev/message/1521).
Currently `libbpf` is published from kernel sources, e.g. [[2]](https://packages.debian.org/sid/libbpf4.19) and [[3]](http://rpmfind.net/linux/RPM/fedora/devel/rawhide/x86_64/l/libbpf-5.3.0-0.rc2.git0.1.fc31.x86_64.html). The ideal situation is `libbpf` package published from this github mirror, so there are advantages of

- consistent versioning across distros
- testability provided by Travis CI
- ability to build w/o kernel tree
- ability to merge changes directly to libbpf

This spec may be used as a starting point. 

The present value of `Version` matches with the current ABI version: 0.0.4.

Specifies libbpf and libbpf-devel packages.

```
% rpm -qlp libbpf-devel-0.0.4-1.el7.x86_64.rpm
/usr/include/bpf/bpf.h
/usr/include/bpf/btf.h
/usr/include/bpf/libbpf.h
/usr/include/bpf/libbpf_util.h
/usr/include/bpf/xsk.h
/usr/lib64/libbpf.a
/usr/lib64/pkgconfig/libbpf.pc
```

```
% rpm -qlp libbpf-0.0.4-1.el7.x86_64.rpm
/usr/lib/.build-id
/usr/lib/.build-id/44
/usr/lib/.build-id/44/dc2673ddfe408e504f0d7166d5d8f8390a0b9f
/usr/lib64/libbpf.so
/usr/lib64/libbpf.so.0
/usr/lib64/libbpf.so.0.0.4
```

[1] https://lists.iovisor.org/g/iovisor-dev/message/1521
[2] https://packages.debian.org/sid/libbpf4.19
[3] http://rpmfind.net/linux/RPM/fedora/devel/rawhide/x86_64/l/libbpf-5.3.0-0.rc2.git0.1.fc31.x86_64.html