### PR TITLE
Fix shared library build with some compilers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -77,9 +77,9 @@ $(OBJDIR)/libbpf.so.$(LIBBPF_MAJOR_VERSION): $(OBJDIR)/libbpf.so.$(LIBBPF_VERSIO
 	ln -sf $(^F) $@
 
 $(OBJDIR)/libbpf.so.$(LIBBPF_VERSION): $(OBJS)
-	$(CC) -shared $(ALL_LDFLAGS) -Wl,--version-script=$(VERSION_SCRIPT) \
-				     -Wl,-soname,libbpf.so.$(LIBBPF_MAJOR_VERSION) \
-				     $^ -o $@
+	$(CC) -shared -Wl,--version-script=$(VERSION_SCRIPT) \
+		      -Wl,-soname,libbpf.so.$(LIBBPF_MAJOR_VERSION) \
+		      $^ $(ALL_LDFLAGS) -o $@
 
 $(OBJDIR)/libbpf.pc:
 	sed -e "s|@PREFIX@|$(PREFIX)|" \

--- a/travis-ci/managers/debian.sh
+++ b/travis-ci/managers/debian.sh
@@ -13,6 +13,10 @@ function info() {
     echo -e "\033[33;1m$1\033[0m"
 }
 
+function error() {
+    echo -e "\033[31;1m$1\033[0m"
+}
+
 function docker_exec() {
     docker exec $ENV_VARS -it $CONT_NAME "$@"
 }
@@ -48,6 +52,12 @@ for phase in "${PHASES[@]}"; do
             docker_exec mkdir build
             docker_exec ${CC:-cc} --version
             docker_exec make CFLAGS="${CFLAGS}" -C ./src -B OBJDIR=../build
+            info "ldd build/libbpf.so:"
+            docker_exec ldd build/libbpf.so
+            if ! docker_exec ldd build/libbpf.so | grep -q libelf; then
+                error "No reference to libelf.so in libbpf.so!"
+                exit 1
+            fi
             docker_exec rm -rf build
             ;;
         RUN_ASAN|RUN_CLANG_ASAN|RUN_GCC8_ASAN)
@@ -62,6 +72,12 @@ for phase in "${PHASES[@]}"; do
             docker_exec mkdir build
             docker_exec ${CC:-cc} --version
             docker_exec make CFLAGS="${CFLAGS}" -C ./src -B OBJDIR=../build
+            info "ldd build/libbpf.so:"
+            docker_exec ldd build/libbpf.so
+            if ! docker_exec ldd build/libbpf.so | grep -q libelf; then
+                error "No reference to libelf.so in libbpf.so!"
+                exit 1
+            fi
             docker_exec rm -rf build
             ;;
         CLEANUP)

--- a/travis-ci/managers/xenial.sh
+++ b/travis-ci/managers/xenial.sh
@@ -14,4 +14,9 @@ CFLAGS="-g -O2 -Werror -Wall -fsanitize=address,undefined"
 mkdir build
 cc --version
 make CFLAGS="${CFLAGS}" -C ./src -B OBJDIR=../build
+ldd build/libbpf.so
+if ! ldd build/libbpf.so | grep -q libelf; then
+    echo "FAIL: No reference to libelf.so in libbpf.so!"
+    exit 1
+fi
 rm -rf build


### PR DESCRIPTION
See commit log of second commit for more details. The first commit introduces a check for this bug into Travis CI. You can verify it fails on Debian Testing and Xenial and passes after this commit. Note that there is a pre-existing build failure with ASan+UBSan due to static checker warnings.