### PR TITLE
libbpf: fix Github-only indentation issue

### DIFF
--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -3375,11 +3375,11 @@ load_program(struct bpf_program *prog, struct bpf_insn *insns, int insns_cnt,
 	load_attr.license = license;
 	load_attr.kern_version = kern_version;
 	load_attr.prog_ifindex = prog->prog_ifindex;
-        /* if .BTF.ext was loaded, kernel supports associated BTF for prog */
-        if (prog->obj->btf_ext)
-                btf_fd = bpf_object__btf_fd(prog->obj);
-        else
-                btf_fd = -1;
+	/* if .BTF.ext was loaded, kernel supports associated BTF for prog */
+	if (prog->obj->btf_ext)
+		btf_fd = bpf_object__btf_fd(prog->obj);
+	else
+		btf_fd = -1;
 	load_attr.prog_btf_fd = btf_fd >= 0 ? btf_fd : 0;
 	load_attr.func_info = prog->func_info;
 	load_attr.func_info_rec_size = prog->func_info_rec_size;


### PR DESCRIPTION
When appying urgent fix to Github mirror, before it was pushed to linux
repo, there were some indentation issues, which eventually got fixed
upstream, but are still in Github mirror. Fix it to prevent future merge
conflicts.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>