### PR TITLE
makefile: Fix install target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -116,7 +116,11 @@ define do_s_install
 endef
 
 install: all install_headers install_pkgconfig
-	$(call do_s_install,$(LIBS),$(LIBDIR))
+ifndef BUILD_STATIC_ONLY
+	$(call do_s_install,$(SHARED_LIBS) $(STATIC_LIBS),$(LIBDIR))
+else
+	${call do_s_install,$(STATIC_LIBS),$(LIBDIR))
+endif
 
 install_headers:
 	$(call do_install,$(HEADERS),$(INCLUDEDIR)/bpf,644)


### PR DESCRIPTION
Before this change, the install target was failing with the following
error:

```
  make: Entering directory '/home/mrostecki/repos/libbpf/src'
  if [ ! -d '/usr/include/bpf' ]; then install -d -m 755 '/usr/include/bpf'; fi; install bpf.h libbpf.h btf.h xsk.h libbpf_util.h -m 644 '/usr/include/bpf'
  if [ ! -d '/usr/lib64/pkgconfig' ]; then install -d -m 755 '/usr/lib64/pkgconfig'; fi; install ./libbpf.pc -m 644 '/usr/lib64/pkgconfig'
  if [ ! -d '/usr/lib64' ]; then install -d -m 755 '/usr/lib64'; fi; cp -fpR  '/usr/lib64'
  cp: missing destination file operand after '/usr/lib64'
  Try 'cp --help' for more information.
  make: *** [Makefile:119: install] Error 1
  make: Leaving directory '/home/mrostecki/repos/libbpf/src'
```

That error occured due to usage of non-existing variable $(LIBS). After
this change, $(SHARED_LIBS) and $(STATIC_LIBS) are used instead, which
fixes the behavior of the install target.

Fixes: 8b2782a1f250 ("makefile: support libbpf symbol versioning in shared library mode")
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>