### PR TITLE
travis: add an aarch64 Xenial job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,3 +120,11 @@ jobs:
               - set -e
               - sudo $CI_MANAGERS/xenial.sh
               - set +e
+
+        - name: Ubuntu Xenial (arm)
+          arch: arm64
+          language: bash
+          script:
+              - set -e
+              - sudo $CI_MANAGERS/xenial.sh
+              - set +e

--- a/travis-ci/managers/xenial.sh
+++ b/travis-ci/managers/xenial.sh
@@ -2,9 +2,11 @@
 set -e
 set -x
 
+echo 'deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse' >>/etc/apt/sources.list
+
 apt-get update
 apt-get -y build-dep libelf-dev
-apt-get install -y libelf-dev
+apt-get install -y libelf-dev pkg-config
 
 source "$(dirname $0)/travis_wait.bash"
 


### PR DESCRIPTION
As Travis now [supports](https://docs.travis-ci.com/user/multi-cpu-architectures) aarch64 along with x86_64, let's make use of it, in light of the recent aarch64-related issues. This could be, theoretically, extended to other jobs, as you can run a Docker container in LXD, but not the privileged one (which shouldn't be an issue for libbpf, as it is in [systemd](https://github.com/systemd/systemd/pull/13785#issuecomment-544485154)).