### PR TITLE
lgtm: fix the extraction process

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,14 @@
+# vi: set ts=2 sw=2:
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - libelf-dev
+        - pkg-config
+    after_prepare:
+      # As the buildsystem detection by LGTM is performed _only_ during the
+      # 'configure' phase, we need to trick LGTM we use a supported build
+      # system (configure, meson, cmake, etc.). This way LGTM correctly detects
+      # that our sources are in the src/ subfolder.
+      - touch src/configure
+      - chmod +x src/configure


### PR DESCRIPTION
This PR fixes the LGTM analysis.

As this project uses only Makefile, without any configuration step, and due to a "non-standard" location of the source files, LGTM kept failing to find the respective Makefile and build the sources. By tricking LGTM's build system auto detection, that we use automake/configure, it correctly sets the source dir, thus the compilation, extraction & analysis steps now work in the `src/` subdirectory, as expected.

~~The `CFLAGS=-Wno-stringop-overflow` workaround should stay there only until #87 is resolved.~~

As mentioned in the comment below, I played around with the LGTM configuration in a separate repository, so you can see it in action before merging this PR:

 - LGTM results: https://lgtm.com/projects/g/mrc0mmand/libbpf-lgtm-test/
 - PR comments: https://github.com/mrc0mmand/libbpf-lgtm-test/pull/1#issuecomment-545898862

After merging this PR, simple build retry in the LGTM web UI should "unlock" the access to enable auto PR reviews and other useful settings.