### PR TITLE
travis: automate Coverity builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,19 @@ services:
 
 env:
     global:
-        - AUTHOR_EMAIL="$(git log -1 $TRAVIS_COMMIT --pretty=\"%aE\")"
+        - AUTHOR_EMAIL="$(git log -1 --pretty=\"%aE\")"
         - CI_MANAGERS="$TRAVIS_BUILD_DIR/travis-ci/managers"
         - REPO_ROOT="$TRAVIS_BUILD_DIR"
+
+stages:
+    # Run Coverity periodically instead of for each PR for following reasons:
+    # 1) Coverity jobs are heavily rate-limited
+    # 2) Due to security restrictions of encrypted environment variables
+    #    in Travis CI, pull requests made from forks can't access encrypted
+    #    env variables, making Coverity unusable
+    #    See: https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
+    - name: Coverity
+      if: type = cron
 
 jobs:
     include:
@@ -127,4 +137,27 @@ jobs:
           script:
               - set -e
               - sudo $CI_MANAGERS/xenial.sh
+              - set +e
+
+        - stage: Coverity
+          language: bash
+          env:
+              # Coverity configuration
+              # COVERITY_SCAN_TOKEN=xxx
+              # Encrypted using `travis encrypt --repo libbpf/libbpf COVERITY_SCAN_TOKEN=xxx`
+              - secure: "I9OsMRHbb82IUivDp+I+w/jEQFOJgBDAqYqf1ollqCM1QhocxMcS9bwIAgfPhdXi2hohV7sRrVMZstahY67FAvJLGxNopi4tAPDIAaIFxgO0yDxMhaTMx5xDfMwlIm2FOP/9gB9BQsd6M7CmoQZgXYwBIv7xd1ooxoQrh2rOK1YrRl7UQu3+c3zPTjDfIYZzR3bFttMqZ9/c4U0v8Ry5IFXrel3hCshndHA1TtttJrUSrILlZcmVc1ch7JIy6zCbCU/2lGv0B/7rWXfF8MT7O9jPtFOhJ1DEcd2zhw2n4j9YT3a8OhtnM61LA6ask632mwCOsxpFLTun7AzuR1Cb5mdPHsxhxnCHcXXARa2mJjem0QG1NhwxwJE8sbRDapojexxCvweYlEN40ofwMDSnj/qNt95XIcrk0tiIhGFx0gVNWvAdmZwx+N4mwGPMTAN0AEOFjpgI+ZdB89m+tL/CbEgE1flc8QxUxJhcp5OhH6yR0z9qYOp0nXIbHsIaCiRvt/7LqFRQfheifztWVz4mdQlCdKS9gcOQ09oKicPevKO1L0Ue3cb7Ug7jOpMs+cdh3XokJtUeYEr1NijMHT9+CTAhhO5RToWXIZRon719z3fwoUBNDREATwVFMlVxqSO/pbYgaKminigYbl785S89YYaZ6E5UvaKRHM6KHKMDszs="
+              - COVERITY_SCAN_PROJECT_NAME="libbpf"
+              - COVERITY_SCAN_NOTIFICATION_EMAIL="${AUTHOR_EMAIL}"
+              - COVERITY_SCAN_BRANCH_PATTERN="$TRAVIS_BRANCH"
+              # Note: `make -C src/` as a BUILD_COMMAND will not work here
+              - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cd src/"
+              - COVERITY_SCAN_BUILD_COMMAND="make"
+          install:
+              - echo 'deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse' >>/etc/apt/sources.list
+              - apt-get update
+              - apt-get -y build-dep libelf-dev
+              - apt-get install -y libelf-dev pkg-config
+          script:
+              - set -e
+              - scripts/coverity.sh
               - set +e

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ successful.
 Build
 [![Build Status](https://travis-ci.org/libbpf/libbpf.svg?branch=master)](https://travis-ci.org/libbpf/libbpf)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/libbpf/libbpf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/libbpf/libbpf/alerts/)
+[![Coverity](https://img.shields.io/coverity/scan/18195.svg)](https://scan.coverity.com/projects/libbpf)
 =====
 libelf is an internal dependency of libbpf and thus it is required to link
 against and must be installed on the system for applications to work.

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Taken from: https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh
+# Local changes are annotated with "#[local]"
+
+set -e
+
+# Environment check
+echo -e "\033[33;1mNote: COVERITY_SCAN_PROJECT_NAME and COVERITY_SCAN_TOKEN are available on Project Settings page on scan.coverity.com\033[0m"
+[ -z "$COVERITY_SCAN_PROJECT_NAME" ] && echo "ERROR: COVERITY_SCAN_PROJECT_NAME must be set" && exit 1
+[ -z "$COVERITY_SCAN_NOTIFICATION_EMAIL" ] && echo "ERROR: COVERITY_SCAN_NOTIFICATION_EMAIL must be set" && exit 1
+[ -z "$COVERITY_SCAN_BRANCH_PATTERN" ] && echo "ERROR: COVERITY_SCAN_BRANCH_PATTERN must be set" && exit 1
+[ -z "$COVERITY_SCAN_BUILD_COMMAND" ] && echo "ERROR: COVERITY_SCAN_BUILD_COMMAND must be set" && exit 1
+[ -z "$COVERITY_SCAN_TOKEN" ] && echo "ERROR: COVERITY_SCAN_TOKEN must be set" && exit 1
+
+PLATFORM=`uname`
+#[local] Use /var/tmp for TOOL_ARCHIVE and TOOL_BASE, as on certain systems
+# /tmp is tmpfs and is sometimes too small to handle all necessary tooling
+TOOL_ARCHIVE=/var//tmp/cov-analysis-${PLATFORM}.tgz
+TOOL_URL=https://scan.coverity.com/download/${PLATFORM}
+TOOL_BASE=/var/tmp/coverity-scan-analysis
+UPLOAD_URL="https://scan.coverity.com/builds"
+SCAN_URL="https://scan.coverity.com"
+
+# Do not run on pull requests
+if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then
+  echo -e "\033[33;1mINFO: Skipping Coverity Analysis: branch is a pull request.\033[0m"
+  exit 0
+fi
+
+# Verify this branch should run
+IS_COVERITY_SCAN_BRANCH=`ruby -e "puts '${TRAVIS_BRANCH}' =~ /\\A$COVERITY_SCAN_BRANCH_PATTERN\\z/ ? 1 : 0"`
+if [ "$IS_COVERITY_SCAN_BRANCH" = "1" ]; then
+  echo -e "\033[33;1mCoverity Scan configured to run on branch ${TRAVIS_BRANCH}\033[0m"
+else
+  echo -e "\033[33;1mCoverity Scan NOT configured to run on branch ${TRAVIS_BRANCH}\033[0m"
+  exit 1
+fi
+
+# Verify upload is permitted
+AUTH_RES=`curl -s --form project="$COVERITY_SCAN_PROJECT_NAME" --form token="$COVERITY_SCAN_TOKEN" $SCAN_URL/api/upload_permitted`
+if [ "$AUTH_RES" = "Access denied" ]; then
+  echo -e "\033[33;1mCoverity Scan API access denied. Check COVERITY_SCAN_PROJECT_NAME and COVERITY_SCAN_TOKEN.\033[0m"
+  exit 1
+else
+  AUTH=`echo $AUTH_RES | ruby -e "require 'rubygems'; require 'json'; puts JSON[STDIN.read]['upload_permitted']"`
+  if [ "$AUTH" = "true" ]; then
+    echo -e "\033[33;1mCoverity Scan analysis authorized per quota.\033[0m"
+  else
+    WHEN=`echo $AUTH_RES | ruby -e "require 'rubygems'; require 'json'; puts JSON[STDIN.read]['next_upload_permitted_at']"`
+    echo -e "\033[33;1mCoverity Scan analysis NOT authorized until $WHEN.\033[0m"
+    exit 0
+  fi
+fi
+
+if [ ! -d $TOOL_BASE ]; then
+  # Download Coverity Scan Analysis Tool
+  if [ ! -e $TOOL_ARCHIVE ]; then
+    echo -e "\033[33;1mDownloading Coverity Scan Analysis Tool...\033[0m"
+    wget -nv -O $TOOL_ARCHIVE $TOOL_URL --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=$COVERITY_SCAN_TOKEN"
+  fi
+
+  # Extract Coverity Scan Analysis Tool
+  echo -e "\033[33;1mExtracting Coverity Scan Analysis Tool...\033[0m"
+  mkdir -p $TOOL_BASE
+  pushd $TOOL_BASE
+  tar xzf $TOOL_ARCHIVE
+  popd
+fi
+
+TOOL_DIR=`find $TOOL_BASE -type d -name 'cov-analysis*'`
+export PATH=$TOOL_DIR/bin:$PATH
+
+# Build
+echo -e "\033[33;1mRunning Coverity Scan Analysis Tool...\033[0m"
+COV_BUILD_OPTIONS=""
+#COV_BUILD_OPTIONS="--return-emit-failures 8 --parse-error-threshold 85"
+RESULTS_DIR="cov-int"
+eval "${COVERITY_SCAN_BUILD_COMMAND_PREPEND}"
+COVERITY_UNSUPPORTED=1 cov-build --dir $RESULTS_DIR $COV_BUILD_OPTIONS $COVERITY_SCAN_BUILD_COMMAND
+cov-import-scm --dir $RESULTS_DIR --scm git --log $RESULTS_DIR/scm_log.txt 2>&1
+
+# Upload results
+echo -e "\033[33;1mTarring Coverity Scan Analysis results...\033[0m"
+RESULTS_ARCHIVE=analysis-results.tgz
+tar czf $RESULTS_ARCHIVE $RESULTS_DIR
+SHA=`git rev-parse --short HEAD`
+
+echo -e "\033[33;1mUploading Coverity Scan Analysis results...\033[0m"
+response=$(curl \
+  --silent --write-out "\n%{http_code}\n" \
+  --form project=$COVERITY_SCAN_PROJECT_NAME \
+  --form token=$COVERITY_SCAN_TOKEN \
+  --form email=$COVERITY_SCAN_NOTIFICATION_EMAIL \
+  --form file=@$RESULTS_ARCHIVE \
+  --form version=$SHA \
+  --form description="Travis CI build" \
+  $UPLOAD_URL)
+status_code=$(echo "$response" | sed -n '$p')
+#[local] Coverity used to return 201 on success, but it's 200 now
+# See https://github.com/systemd/systemd/blob/master/tools/coverity.sh#L145
+if [ "$status_code" != "200" ]; then
+  TEXT=$(echo "$response" | sed '$d')
+  echo -e "\033[33;1mCoverity Scan upload failed: $TEXT.\033[0m"
+  exit 1
+fi


### PR DESCRIPTION
Let's automate Coverity builds as well, to improve code quality. 

As the build frequency is rate limited, the Coverity runs are limited to the master branch only - that means someone with appropriate privileges has to setup a Travis CI cron job, which would run Travis once per day on the master branch, to get the optimal results.

~~Marking as WIP for now, as I've never used the Travis CI `coverity_scan` addon before, so I'd like to make sure it works as expected.~~ It appears that the `coverity_scan` addon is not as versatile as I'd like it to be, so let's fall back to the *manual* method I'm familiar with.