### PR TITLE
coverity: explicitly use bash instead of sh

### DIFF
--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Taken from: https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh
 # Local changes are annotated with "#[local]"
 


### PR DESCRIPTION
On Ubuntu `/bin/sh` is a symlink to `/bin/dash`, which doesn't support
certain builtins used by the Coverity script (namely pushd/popd)

---

Hopefully a last follow-up for the Coverity-related stuff.