### PR TITLE
travis: add an s390x job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 services:
     - docker
 
@@ -124,27 +124,27 @@ jobs:
           after_script:
               - $CI_MANAGERS/debian.sh CLEANUP
 
-        - name: Ubuntu Xenial
+        - name: Ubuntu Bionic
           language: bash
           script:
               - set -e
-              - sudo $CI_MANAGERS/xenial.sh
+              - sudo $CI_MANAGERS/ubuntu.sh
               - set +e
 
-        - name: Ubuntu Xenial (arm)
+        - name: Ubuntu Bionic (arm)
           arch: arm64
           language: bash
           script:
               - set -e
-              - sudo $CI_MANAGERS/xenial.sh
+              - sudo $CI_MANAGERS/ubuntu.sh
               - set +e
 
-        - name: Ubuntu Xenial (s390x)
+        - name: Ubuntu Bionic (s390x)
           arch: s390x
           language: bash
           script:
               - set -e
-              - sudo $CI_MANAGERS/xenial.sh
+              - sudo $CI_MANAGERS/ubuntu.sh
               - set +e
 
         - stage: Coverity
@@ -161,7 +161,7 @@ jobs:
               - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cd src/"
               - COVERITY_SCAN_BUILD_COMMAND="make"
           install:
-              - sudo echo 'deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse' >>/etc/apt/sources.list
+              - sudo echo 'deb-src http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse' >>/etc/apt/sources.list
               - sudo apt-get update
               - sudo apt-get -y build-dep libelf-dev
               - sudo apt-get install -y libelf-dev pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,7 @@ jobs:
           install:
               - $CI_MANAGERS/debian.sh SETUP
           script:
-              - set -e
-              - $CI_MANAGERS/debian.sh RUN
-              - set +e
+              - $CI_MANAGERS/debian.sh RUN || travis_terminate
           after_script:
               - $CI_MANAGERS/debian.sh CLEANUP
 
@@ -50,9 +48,7 @@ jobs:
           install:
               - $CI_MANAGERS/debian.sh SETUP
           script:
-              - set -e
-              - $CI_MANAGERS/debian.sh RUN_ASAN
-              - set +e
+              - $CI_MANAGERS/debian.sh RUN_ASAN || travis_terminate
           after_script:
               - $CI_MANAGERS/debian.sh CLEANUP
 
@@ -67,9 +63,7 @@ jobs:
           install:
               - $CI_MANAGERS/debian.sh SETUP
           script:
-              - set -e
-              - $CI_MANAGERS/debian.sh RUN_CLANG
-              - set +e
+              - $CI_MANAGERS/debian.sh RUN_CLANG || travis_terminate
           after_script:
               - $CI_MANAGERS/debian.sh CLEANUP
 
@@ -84,9 +78,7 @@ jobs:
           install:
               - $CI_MANAGERS/debian.sh SETUP
           script:
-              - set -e
-              - $CI_MANAGERS/debian.sh RUN_CLANG_ASAN
-              - set +e
+              - $CI_MANAGERS/debian.sh RUN_CLANG_ASAN || travis_terminate
           after_script:
               - $CI_MANAGERS/debian.sh CLEANUP
 
@@ -101,9 +93,7 @@ jobs:
           install:
               - $CI_MANAGERS/debian.sh SETUP
           script:
-              - set -e
-              - $CI_MANAGERS/debian.sh RUN_GCC8
-              - set +e
+              - $CI_MANAGERS/debian.sh RUN_GCC8 || travis_terminate
           after_script:
               - $CI_MANAGERS/debian.sh CLEANUP
 
@@ -118,34 +108,26 @@ jobs:
           install:
               - $CI_MANAGERS/debian.sh SETUP
           script:
-              - set -e
-              - $CI_MANAGERS/debian.sh RUN_GCC8_ASAN
-              - set +e
+              - $CI_MANAGERS/debian.sh RUN_GCC8_ASAN || travis_terminate
           after_script:
               - $CI_MANAGERS/debian.sh CLEANUP
 
         - name: Ubuntu Bionic
           language: bash
           script:
-              - set -e
-              - sudo $CI_MANAGERS/ubuntu.sh
-              - set +e
+              - sudo $CI_MANAGERS/ubuntu.sh || travis_terminate
 
         - name: Ubuntu Bionic (arm)
           arch: arm64
           language: bash
           script:
-              - set -e
-              - sudo $CI_MANAGERS/ubuntu.sh
-              - set +e
+              - sudo $CI_MANAGERS/ubuntu.sh || travis_terminate
 
         - name: Ubuntu Bionic (s390x)
           arch: s390x
           language: bash
           script:
-              - set -e
-              - sudo $CI_MANAGERS/ubuntu.sh
-              - set +e
+              - sudo $CI_MANAGERS/ubuntu.sh || travis_terminate
 
         - stage: Coverity
           language: bash
@@ -166,6 +148,4 @@ jobs:
               - sudo apt-get -y build-dep libelf-dev
               - sudo apt-get install -y libelf-dev pkg-config
           script:
-              - set -e
-              - scripts/coverity.sh
-              - set +e
+              - scripts/coverity.sh || travis_terminate

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,14 @@ jobs:
               - sudo $CI_MANAGERS/xenial.sh
               - set +e
 
+        - name: Ubuntu Xenial (s390x)
+          arch: s390x
+          language: bash
+          script:
+              - set -e
+              - sudo $CI_MANAGERS/xenial.sh
+              - set +e
+
         - stage: Coverity
           language: bash
           env:

--- a/travis-ci/managers/ubuntu.sh
+++ b/travis-ci/managers/ubuntu.sh
@@ -2,7 +2,9 @@
 set -e
 set -x
 
-echo 'deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse' >>/etc/apt/sources.list
+RELEASE="bionic"
+
+echo "deb-src http://archive.ubuntu.com/ubuntu/ $RELEASE main restricted universe multiverse" >>/etc/apt/sources.list
 
 apt-get update
 apt-get -y build-dep libelf-dev


### PR DESCRIPTION
Travis now supports IBM Z and IBM Power architectures, so let's enable
them in our CI as well.

See: https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z