### PR TITLE
include <linux/stddef.h> to get macro defintions

### DIFF
--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <asm/unistd.h>
+#include <linux/stddef.h> // Not alphabetical - Get required macro definitions
 #include <linux/err.h>
 #include <linux/kernel.h>
 #include <linux/bpf.h>


### PR DESCRIPTION
include <linux/stddef.h> to get macro defintions for compiling on Alpine Linux 3.10

Otherwise, macros like `__always_inline` and `__cpu_to_be64p` are undefined.