### PR TITLE
Add -fPIC for static objects

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,7 @@ ifneq ($(FEATURE_REALLOCARRAY),)
 endif
 
 SHARED_CFLAGS += -fPIC -fvisibility=hidden -DSHARED
+STATIC_CFLAGS += -fPIC
 
 CFLAGS ?= -g -O2 -Werror -Wall
 ALL_CFLAGS += $(CFLAGS) -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
@@ -97,7 +98,7 @@ $(SHARED_OBJDIR):
 	mkdir -p $(SHARED_OBJDIR)
 
 $(STATIC_OBJDIR)/%.o: %.c | $(STATIC_OBJDIR)
-	$(CC) $(ALL_CFLAGS) $(CPPFLAGS) -c $< -o $@
+	$(CC) $(ALL_CFLAGS) $(STATIC_CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 $(SHARED_OBJDIR)/%.o: %.c | $(SHARED_OBJDIR)
 	$(CC) $(ALL_CFLAGS) $(SHARED_CFLAGS) $(CPPFLAGS) -c $< -o $@


### PR DESCRIPTION
When using the libbpf.a in bcc's shared library build
I'm getting following compile error:

  [ 10%] Linking CXX shared library libbcc.so
  /usr/bin/ld: libbcc_bpf.a(libbpf.o): relocation R_X86_64_PC32 against       \
    symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; \
    recompile with -fPIC

Adding the -fPIC also for static objects, so it can
be used to build position independent code.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>