### PR TITLE
libbpf: fix Coverity scan CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,12 @@ jobs:
           env:
               - DEBIAN_RELEASE="testing"
               - CONT_NAME="libbpf-debian-$DEBIAN_RELEASE"
-          # Override before_install: so VMTEST before_install commands are not executed.
           before_install:
               - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
               - docker --version
           install:
               - $CI_MANAGERS/debian.sh SETUP
+          # Override before_script: so VMTEST before_install commands are not executed.
           before_script:
           script:
               - $CI_MANAGERS/debian.sh RUN || travis_terminate
@@ -188,5 +188,7 @@ jobs:
               - sudo apt-get update
               - sudo apt-get -y build-dep libelf-dev
               - sudo apt-get install -y libelf-dev pkg-config
+          # Override before_script: so VMTEST before_script commands are not executed.
+          before_script:
           script:
               - scripts/coverity.sh || travis_terminate


### PR DESCRIPTION
A follow up of [1]
Travis CI stages use default phases when no override provided.
This leads to Coverity scan stage fail due to execuing the default
before_script: phase of VMTEST.
Fix this with an explicit override with empty value.

[1] https://github.com/libbpf/libbpf/pull/108