### PR TITLE
vmtest: enable more networking kernel selftests

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-5.5.0
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-5.5.0
@@ -1,13 +1,10 @@
 bpf_tcp_ca
-cgroup_attach_autodetach
 cgroup_attach_multi
-cgroup_attach_override
 fexit_bpf2bpf
 perf_branches
 select_reuseport
 send_signal
 skb_ctx
-sockmap_ktls
 sockmap_listen
 sockopt_inherit
 spinlock

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,11 +1,5 @@
-bpf_tcp_ca
-cgroup_attach_autodetach
-cgroup_attach_multi
-cgroup_attach_override
-select_reuseport
 send_signal_tracepoint
 send_signal_tracepoint_thread
-sockmap_ktls
 sockmap_listen
 sockopt_inherit
 spinlock

--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -5,6 +5,8 @@ set -eux
 mount -t bpf bpffs /sys/fs/bpf
 mount -t debugfs none /sys/kernel/debug/
 
+ip link set lo up
+
 configs_path='libbpf/travis-ci/vmtest/configs'
 blacklist_path="$configs_path/blacklist/BLACKLIST-${KERNEL}"
 if [[ -s "${blacklist_path}" ]]; then


### PR DESCRIPTION
Set up loopback to enable more tests:
- bpf_tcp_ca
- cgroup_attach_autodetach
- cgroup_attach_multi
- cgroup_attach_override
- select_reuseport
- sockmap_ktls

Signed-off-by: Julia Kartseva hex@fb.com