### PR TITLE
ci: update image index and enable sk_assign selftest

### DIFF
--- a/travis-ci/vmtest/configs/INDEX
+++ b/travis-ci/vmtest/configs/INDEX
@@ -1,5 +1,6 @@
 INDEX	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/INDEX
 libbpf-vmtest-rootfs-2020.03.11.tar.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.03.11.tar.zst
+libbpf-vmtest-rootfs-2020.04.02.tar.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.04.02.tar.zst
 vmlinux-5.5.0-rc6.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0-rc6.zst
 vmlinux-5.5.0.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst
 vmlinuz-5.5.0-rc6	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0-rc6

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,4 +1,3 @@
 # TEMPORARILY DISABLED
 send_signal		# flaky
 test_lsm		# semi-working
-sk_assign		# needs better setup in Travis CI

--- a/travis-ci/vmtest/mkrootfs.sh
+++ b/travis-ci/vmtest/mkrootfs.sh
@@ -81,6 +81,7 @@ packages=(
 	binutils
 	elfutils
 	glibc
+	iproute2
 	# selftests test_verifier dependencies.
 	libcap
 )


### PR DESCRIPTION
Image was updated to include iproute2 package, which is a requirement for
sk_assign selftests. So enable it now.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>