### PR TITLE
vmtest: update root fs, whitelist sk_assign test

### DIFF
--- a/travis-ci/vmtest/configs/INDEX
+++ b/travis-ci/vmtest/configs/INDEX
@@ -1,5 +1,5 @@
 INDEX	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/INDEX
-libbpf-vmtest-rootfs-2020.03.11.tar.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.03.11.tar.zst
+libbpf-vmtest-rootfs-2020.09.27.tar.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.09.27.tar.zst
 vmlinux-4.9.0.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-4.9.0.zst
 vmlinux-5.5.0-rc6.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0-rc6.zst
 vmlinux-5.5.0.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,7 +1,5 @@
 # TEMPORARILY DISABLED
 send_signal		# flaky
 test_lsm		# semi-working
-sk_assign		# needs better setup in Travis CI
-sk_lookup
 core_reloc		# temporary test breakage
 bpf_verif_scale		# clang regression

--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -411,7 +411,7 @@ if [[ ! -z SETUPCMD ]]; then
 	if [[ -v BUILDDIR ]]; then kernel='latest'; fi
 	setup_envvars="export KERNEL=${kernel}"
 	setup_script=$(printf "#!/bin/sh
-set -e
+set -eux
 
 echo 'Running setup commands'
 %s


### PR DESCRIPTION
1. Update mkrootfs.sh building root fs
- Remove /etc/fstab from root fs and mount each fs type separately in
S10-mount script.
- devtmpfs can be already mounted prior to S10-mount execution so make
it opt-out. This addresses [0].
- set -eux for scripts
2. Add iproute2 to root fs and whitelist sk_assign test. Addresses
[1][2]. Update INDEX file with 2020-09-27 version.

[0] https://github.com/libbpf/libbpf/pull/145#issuecomment-609673493
[1] https://github.com/libbpf/libbpf/pull/144
[2] https://github.com/libbpf/libbpf/pull/145