### PR TITLE
Makefile: Fix FEATURE_REALLOCARRAY comparison condition

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ INCLUDES := -I. -I$(TOPDIR)/include -I$(TOPDIR)/include/uapi
 ALL_CFLAGS := $(INCLUDES)
 
 FEATURE_REALLOCARRAY := $(shell $(TOPDIR)/scripts/check-reallocarray.sh)
-ifneq ($(FEATURE_REALLOCARRAY),)
+ifneq ($(FEATURE_REALLOCARRAY), FAIL)
 	ALL_CFLAGS += -DCOMPAT_NEED_REALLOCARRAY
 endif
 


### PR DESCRIPTION
Fix build error 
```
BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=root make
cc -I. -I../include -I../include/uapi -DCOMPAT_NEED_REALLOCARRAY -g -O2 -Werror -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64   -c libbpf.c -o build/staticobjs/libbpf.o
In file included from libbpf.c:47:
../include/tools/libc_compat.h:11:21: error: static declaration of 'reallocarray' follows non-static declaration
static inline void *reallocarray(void *ptr, size_t nmemb, size_t size)
                    ^
/usr/include/stdlib.h:559:14: note: previous declaration is here
extern void *reallocarray (void *__ptr, size_t __nmemb, size_t __size)
             ^
1 error generated.
make: *** [Makefile:103: build/staticobjs/libbpf.o] Error 1
```