### PR TITLE
travis_ci: run tests for 4.9 kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,11 @@ jobs:
           language: bash
           script: sudo $CI_ROOT/managers/ubuntu.sh || travis_terminate 1
 
+        - name: Kernel 4.9.0 + selftests
+          language: bash
+          env: KERNEL=4.9.0
+          script:  $CI_ROOT/vmtest/run_vmtest.sh || travis_terminate 1
+
         - name: Kernel 5.5.0 + selftests
           language: bash
           env: KERNEL=5.5.0
@@ -121,3 +126,5 @@ jobs:
               - sudo apt-get install -y libelf-dev pkg-config
           script:
               - scripts/coverity.sh || travis_terminate 1
+    allow_failures:
+        - env: KERNEL=4.9.0

--- a/travis-ci/vmtest/configs/INDEX
+++ b/travis-ci/vmtest/configs/INDEX
@@ -1,6 +1,8 @@
 INDEX	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/INDEX
 libbpf-vmtest-rootfs-2020.03.11.tar.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.03.11.tar.zst
+vmlinux-4.9.0.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-4.9.0.zst
 vmlinux-5.5.0-rc6.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0-rc6.zst
 vmlinux-5.5.0.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst
 vmlinuz-5.5.0-rc6	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0-rc6
 vmlinuz-5.5.0	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0
+vmlinuz-4.9.0	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-4.9.0

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-4.9.0
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-4.9.0
@@ -1,0 +1,56 @@
+# PERMANENTLY DISABLED
+align			# verifier output format changed
+bpf_iter		# bpf_iter support is missing
+bpf_obj_id		# bpf_link support missing for GET_OBJ_INFO, GET_FD_BY_ID, etc
+bpf_tcp_ca		# STRUCT_OPS is missing
+
+# latest Clang generates code that fails to verify
+bpf_verif_scale
+#bpf_verif_scale/strobemeta.o
+#bpf_verif_scale/strobemeta_nounroll1.o
+#bpf_verif_scale/strobemeta_nounroll2.o
+
+cgroup_attach_multi	# BPF_F_REPLACE_PROG missing
+cgroup_link		# LINK_CREATE is missing
+cgroup_skb_sk_lookup	# bpf_sk_lookup_tcp() helper is missing
+connect_force_port	# cgroup/get{peer,sock}name{4,6} support is missing
+enable_stats		# BPF_ENABLE_STATS support is missing
+fentry_fexit		# bpf_prog_test_tracing missing
+fentry_test		# bpf_prog_test_tracing missing
+fexit_bpf2bpf		# freplace is missing
+fexit_test		# bpf_prog_test_tracing missing
+flow_dissector		# bpf_link-based flow dissector is in 5.8+
+flow_dissector_reattach
+get_stack_raw_tp	# exercising BPF verifier bug causing infinite loop
+ksyms			# __start_BTF has different name
+link_pinning		# bpf_link is missing
+load_bytes_relative	# new functionality in 5.8
+map_ptr			# test uses BPF_MAP_TYPE_RINGBUF, added in 5.8
+mmap			# 5.5 kernel is too permissive with re-mmaping
+modify_return		# fmod_ret support is missing
+ns_current_pid_tgid	# bpf_get_ns_current_pid_tgid() helper is missing
+perf_branches		# bpf_read_branch_records() helper is missing
+ringbuf			# BPF_MAP_TYPE_RINGBUF is supported in 5.8+
+
+# bug in verifier w/ tracking references
+#reference_tracking/classifier/sk_lookup_success
+reference_tracking
+
+select_reuseport	# UDP support is missing
+sk_assign		# bpf_sk_assign helper missing
+skb_helpers		# helpers added in 5.8+
+sockmap_listen		# no listen socket supportin SOCKMAP
+skb_ctx			# ctx_{size, }_{in, out} in BPF_PROG_TEST_RUN is missing
+test_global_funcs	# kernel doesn't support BTF linkage=global on FUNCs
+test_lsm		# no BPF_LSM support
+test_overhead		# no fmod_ret support
+varlen			# verifier bug fixed in later kernels
+vmlinux			# hrtimer_nanosleep() signature changed incompatibly
+xdp_adjust_tail		# new XDP functionality added in 5.8
+xdp_attach		# IFLA_XDP_EXPECTED_FD support is missing
+xdp_bpf2bpf		# freplace is missing
+
+
+# TEMPORARILY DISABLED
+send_signal		# flaky
+cls_redirect		# latest Clang breaks BPF verification


### PR DESCRIPTION
Make sure that libbpf sanitizes BTF properly for older kernels.
Add a stage for 4.9.0 kernel in TravisCI.
For now make test failures non-blocking by adding 4.9.0 to `allow_failures`
section.
Blacklist is copy-pasted 5.5.0 kernel blacklist.