### PR TITLE
vmtests: test no-alu32 variant of test_progs

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -5,11 +5,13 @@ set -euxo pipefail
 test_progs() {
 	echo TEST_PROGS
 	./test_progs ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST}
+
+	echo TEST_PROGS-NO_ALU32
+	./test_progs-no_alu32 ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST}
 }
 
 test_maps() {
 	echo TEST_MAPS
-	# Allow failing on older kernels.
 	./test_maps
 }
 


### PR DESCRIPTION
Add testing of no-alu32 flavor of test_progs.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>