### PR TITLE
check-reallocarray.sh: Use the same compiler Make does

### DIFF
--- a/scripts/check-reallocarray.sh
+++ b/scripts/check-reallocarray.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Usage: check-reallocarray.sh cc_path [cc_args...]
 
 tfile=$(mktemp /tmp/test_reallocarray_XXXXXXXX.c)
 ofile=${tfile%.c}.o
@@ -13,6 +14,6 @@ int main(void)
 }
 EOL
 
-gcc $tfile -o $ofile >/dev/null 2>&1
+"$@" $tfile -o $ofile >/dev/null 2>&1
 if [ $? -ne 0 ]; then echo "FAIL"; fi
 /bin/rm -f $tfile $ofile

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ TOPDIR = ..
 INCLUDES := -I. -I$(TOPDIR)/include -I$(TOPDIR)/include/uapi
 ALL_CFLAGS := $(INCLUDES)
 
-FEATURE_REALLOCARRAY := $(shell $(TOPDIR)/scripts/check-reallocarray.sh)
+FEATURE_REALLOCARRAY := $(shell $(TOPDIR)/scripts/check-reallocarray.sh $(CC))
 ifneq ($(FEATURE_REALLOCARRAY),)
 	ALL_CFLAGS += -DCOMPAT_NEED_REALLOCARRAY
 endif


### PR DESCRIPTION
Currently we hardcode "gcc", which means we get a bogus result any time a non-default CC is passed to Make. In fact, it's bogus even when `CC` is not explicitly set, since Make's default is "cc", which isn't necessarily the same as "gcc".

Fix the issue by passing the compiler to use to `check-reallocarray.sh`.