### PR TITLE
vmtests: specify v12 of clang/llvm for now

### DIFF
--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -12,8 +12,8 @@ ${VMTEST_ROOT}/build_pahole.sh travis-ci/vmtest/pahole
 # Install required packages
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
-sudo apt-get -qq update
-sudo apt-get -qq -y install clang lld llvm
+sudo apt-get update
+sudo apt-get -y install clang-12 lld-12 llvm-12
 
 # Build selftests (and latest kernel, if necessary)
 KERNEL="${KERNEL}" ${VMTEST_ROOT}/prepare_selftests.sh travis-ci/vmtest/bpf-next


### PR DESCRIPTION
Whatever happened, clang-11 and llvm-11, to which clang/llvm packages resolve,
respectively, are not there anymore. Seems like clang-12/llvm-12 are the
latest now, but for whatever reason clang/llvm don't resolve to them yet.
Hard-code version 12 for now.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>