### PR TITLE
README.md: update Travis CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ should be opened only for dealing with issues pertaining to specific way this
 libbpf mirror repo is set up and organized.
 
 Build
-[![Build Status](https://travis-ci.org/libbpf/libbpf.svg?branch=master)](https://travis-ci.org/libbpf/libbpf)
+[![Build Status](https://travis-ci.com/libbpf/libbpf.svg?branch=master)](https://travis-ci.com/github/libbpf/libbpf)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/libbpf/libbpf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/libbpf/libbpf/alerts/)
 [![Coverity](https://img.shields.io/coverity/scan/18195.svg)](https://scan.coverity.com/projects/libbpf)
 =====


### PR DESCRIPTION
Update Travis CI status badge to point to travis-ci.com,
now that libbpf was migrated there.