### PR TITLE
update bpf_stats_type declaration as c++11 Unscoped enumerations

### DIFF
--- a/src/bpf.h
+++ b/src/bpf.h
@@ -240,7 +240,11 @@ LIBBPF_API int bpf_task_fd_query(int pid, int fd, __u32 flags, char *buf,
 				 __u32 *buf_len, __u32 *prog_id, __u32 *fd_type,
 				 __u64 *probe_offset, __u64 *probe_addr);
 
+#ifdef __cplusplus
+enum bpf_stats_type: int; /* defined in up-to-date linux/bpf.h */
+#else
 enum bpf_stats_type; /* defined in up-to-date linux/bpf.h */
+#endif
 LIBBPF_API int bpf_enable_stats(enum bpf_stats_type type);
 
 #ifdef __cplusplus


### PR DESCRIPTION
when bcc reference bpf.h, compail will has erroe:
file ISO C++ forbids forward references to 'enum' types

Signed-off-by: eason<eason.sheng.chen@gmail.com>