### PR TITLE
README: mention that Debian 11 ships with BTF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Some major Linux distributions come with kernel BTF already built in:
   - OpenSUSE Tumbleweed (in the next release, as of 2020-06-04)
   - Arch Linux (from kernel 5.7.1.arch1-1)
   - Ubuntu 20.10
+  - Debian 11 (amd64/arm64)
 
 If your kernel doesn't come with BTF built-in, you'll need to build custom
 kernel. You'll need:


### PR DESCRIPTION
Only on amd64 and arm64 kernel builds for now, as we had some issues on some less common 32bit architectures. Will update if we change it.