### PR TITLE
vmtest: switch to Clang/LLVM 13

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -6,7 +6,9 @@ source $(cd $(dirname $0) && pwd)/helpers.sh
 
 travis_fold start prepare_selftests "Building selftests"
 
-LLVM_VER=12
+sudo apt-get -y install python-docutils # for rst2man
+
+LLVM_VER=13
 LIBBPF_PATH="${REPO_ROOT}"
 REPO_PATH="travis-ci/vmtest/bpf-next"
 
@@ -28,7 +30,7 @@ make \
 	VMLINUX_BTF="${VMLINUX_BTF}" \
 	VMLINUX_H=${VMLINUX_H} \
 	-C "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
-	-j $((2*$(nproc)))
+	-j $((4*$(nproc)))
 mkdir ${LIBBPF_PATH}/selftests
 cp -R "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
 	${LIBBPF_PATH}/selftests

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -14,12 +14,10 @@ ${VMTEST_ROOT}/build_pahole.sh travis-ci/vmtest/pahole
 
 travis_fold start install_clang "Installing Clang/LLVM"
 
-# Install required packages
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
 sudo apt-get update
-sudo apt-get -y install clang-12 lld-12 llvm-12
-sudo apt-get -y install python-docutils # for rst2man
+sudo apt-get install -y clang-13 lld-13 llvm-13
 
 travis_fold end install_clang
 


### PR DESCRIPTION
Clang 13 became the new nightly version, so switch to it. Also do vmlinux
compilation with a bit more parallelism. And account python-docutils
installation as part of selftests build.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>