### PR TITLE
vmtests: revert to Clang/LLVM 12 until Clang 13 regression is fixed

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -8,7 +8,7 @@ travis_fold start prepare_selftests "Building selftests"
 
 sudo apt-get -y install python-docutils # for rst2man
 
-LLVM_VER=13
+LLVM_VER=12
 LIBBPF_PATH="${REPO_ROOT}"
 REPO_PATH="travis-ci/vmtest/bpf-next"
 

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -15,9 +15,9 @@ ${VMTEST_ROOT}/build_pahole.sh travis-ci/vmtest/pahole
 travis_fold start install_clang "Installing Clang/LLVM"
 
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
+sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main"
 sudo apt-get update
-sudo apt-get install -y clang-13 lld-13 llvm-13
+sudo apt-get install -y clang-12 lld-12 llvm-12
 
 travis_fold end install_clang
 


### PR DESCRIPTION
Clang 13 regressed BPF code generation causing some of BPF selftests to fail.
Until that is mitigated, stick to version 12.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>