### PR TITLE
travis-ci: switch from GCC8 to GCC10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,16 +75,16 @@ jobs:
           script:         $CI_ROOT/managers/debian.sh RUN_CLANG_ASAN || travis_terminate 1
           after_script:   $CI_ROOT/managers/debian.sh CLEANUP
 
-        - name: Debian Build (gcc-8)
+        - name: Debian Build (gcc-10)
           language: bash
           install:        $CI_ROOT/managers/debian.sh SETUP
-          script:         $CI_ROOT/managers/debian.sh RUN_GCC8 || travis_terminate 1
+          script:         $CI_ROOT/managers/debian.sh RUN_GCC10 || travis_terminate 1
           after_script:   $CI_ROOT/managers/debian.sh CLEANUP
 
-        - name: Debian Build (gcc-8 ASan+UBSan)
+        - name: Debian Build (gcc-10 ASan+UBSan)
           language: bash
           install:        $CI_ROOT/managers/debian.sh SETUP
-          script:         $CI_ROOT/managers/debian.sh RUN_GCC8_ASAN || travis_terminate 1
+          script:         $CI_ROOT/managers/debian.sh RUN_GCC10_ASAN || travis_terminate 1
           after_script:   $CI_ROOT/managers/debian.sh CLEANUP
 
         - name: Ubuntu Bionic Build

--- a/travis-ci/managers/debian.sh
+++ b/travis-ci/managers/debian.sh
@@ -6,7 +6,7 @@ CONT_NAME="${CONT_NAME:-libbpf-debian-$DEBIAN_RELEASE}"
 ENV_VARS="${ENV_VARS:-}"
 DOCKER_RUN="${DOCKER_RUN:-docker run}"
 REPO_ROOT="${REPO_ROOT:-$PWD}"
-ADDITIONAL_DEPS=(clang pkg-config gcc-8)
+ADDITIONAL_DEPS=(clang pkg-config gcc-10)
 CFLAGS="-g -O2 -Werror -Wall"
 
 function info() {
@@ -45,13 +45,13 @@ for phase in "${PHASES[@]}"; do
             docker_exec apt-get -y install libelf-dev
             docker_exec apt-get -y install "${ADDITIONAL_DEPS[@]}"
             ;;
-        RUN|RUN_CLANG|RUN_GCC8|RUN_ASAN|RUN_CLANG_ASAN|RUN_GCC8_ASAN)
+        RUN|RUN_CLANG|RUN_GCC10|RUN_ASAN|RUN_CLANG_ASAN|RUN_GCC10_ASAN)
             if [[ "$phase" = *"CLANG"* ]]; then
                 ENV_VARS="-e CC=clang -e CXX=clang++"
                 CC="clang"
-            elif [[ "$phase" = *"GCC8"* ]]; then
-                ENV_VARS="-e CC=gcc-8 -e CXX=g++-8"
-                CC="gcc-8"
+            elif [[ "$phase" = *"GCC10"* ]]; then
+                ENV_VARS="-e CC=gcc-10 -e CXX=g++-10"
+                CC="gcc-10"
             else
                 CFLAGS="${CFLAGS} -Wno-stringop-truncation"
             fi


### PR DESCRIPTION
GCC 8 builds started failing due to missing gcc-8 package. Let's switch to GCC
10 instead.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>