### PR TITLE
Makefile: fix install flags order

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -121,7 +121,7 @@ define do_install
 	$(Q)if [ ! -d '$(DESTDIR)$2' ]; then		\
 		$(INSTALL) -d -m 755 '$(DESTDIR)$2';	\
 	fi;
-	$(Q)$(INSTALL) $1 $(if $3,-m $3,) '$(DESTDIR)$2'
+	$(Q)$(INSTALL) $(if $3,-m $3,) $1 '$(DESTDIR)$2'
 endef
 
 # Preserve symlinks at installation.


### PR DESCRIPTION
Having -m flag between source and destination breaks install on MacOS, as
reported in [0]. Fix it by moving the flag to the front.

  [0] https://github.com/openwrt/openwrt/pull/3959

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>