### PR TITLE
travis-ci: update to Ubuntu Focal [v2.0]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 language: bash
-dist: bionic
+dist: focal
 services:
     - docker
 
@@ -87,21 +87,21 @@ jobs:
           script:         $CI_ROOT/managers/debian.sh RUN_GCC10_ASAN || travis_terminate 1
           after_script:   $CI_ROOT/managers/debian.sh CLEANUP
 
-        - name: Ubuntu Bionic Build
+        - name: Ubuntu Focal Build
           language: bash
           script: sudo $CI_ROOT/managers/ubuntu.sh || travis_terminate 1
 
-        - name: Ubuntu Bionic Build (arm)
+        - name: Ubuntu Focal Build (arm)
           arch: arm64
           language: bash
           script: sudo $CI_ROOT/managers/ubuntu.sh || travis_terminate 1
 
-        - name: Ubuntu Bionic Build (s390x)
+        - name: Ubuntu Focal Build (s390x)
           arch: s390x
           language: bash
           script: sudo $CI_ROOT/managers/ubuntu.sh || travis_terminate 1
 
-        - name: Ubuntu Bionic Build (ppc64le)
+        - name: Ubuntu Focal Build (ppc64le)
           arch: ppc64le
           language: bash
           script: sudo $CI_ROOT/managers/ubuntu.sh || travis_terminate 1
@@ -120,7 +120,7 @@ jobs:
               - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cd src/"
               - COVERITY_SCAN_BUILD_COMMAND="make"
           install:
-              - sudo echo 'deb-src http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse' >>/etc/apt/sources.list
+              - sudo echo 'deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse' >>/etc/apt/sources.list
               - sudo apt-get update
               - sudo apt-get -y build-dep libelf-dev
               - sudo apt-get install -y libelf-dev pkg-config

--- a/travis-ci/managers/debian.sh
+++ b/travis-ci/managers/debian.sh
@@ -21,7 +21,7 @@ function docker_exec() {
     docker exec $ENV_VARS -it $CONT_NAME "$@"
 }
 
-set -e
+set -eu
 
 source "$(dirname $0)/travis_wait.bash"
 

--- a/travis-ci/managers/debian.sh
+++ b/travis-ci/managers/debian.sh
@@ -31,6 +31,18 @@ for phase in "${PHASES[@]}"; do
             info "Setup phase"
             info "Using Debian $DEBIAN_RELEASE"
 
+	    # Install Docker Engine
+            sudo apt-get update
+            sudo apt-get install \
+                apt-transport-https \
+                ca-certificates \
+                curl \
+                gnupg-agent \
+                software-properties-common
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+            sudo add-apt-repository \
+                "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+            sudo apt-get update
             sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
             docker --version
 

--- a/travis-ci/managers/ubuntu.sh
+++ b/travis-ci/managers/ubuntu.sh
@@ -14,7 +14,7 @@ source "$(dirname $0)/travis_wait.bash"
 
 cd $REPO_ROOT
 
-CFLAGS="-g -O2 -Werror -Wall -fsanitize=address,undefined"
+CFLAGS="-g -O2 -Werror -Wall -fsanitize=address,undefined -Wno-stringop-truncation"
 mkdir build install
 cc --version
 make -j$((4*$(nproc))) CFLAGS="${CFLAGS}" -C ./src -B OBJDIR=../build

--- a/travis-ci/managers/ubuntu.sh
+++ b/travis-ci/managers/ubuntu.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-set -e
-set -x
+set -eux
 
 RELEASE="bionic"
 

--- a/travis-ci/managers/ubuntu.sh
+++ b/travis-ci/managers/ubuntu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-RELEASE="bionic"
+RELEASE="focal"
 
 echo "deb-src http://archive.ubuntu.com/ubuntu/ $RELEASE main restricted universe multiverse" >>/etc/apt/sources.list
 

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-5.5.0
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-5.5.0
@@ -66,6 +66,7 @@ socket_cookie		# v5.12+
 sockmap_basic		# uses new socket fields, 5.8+
 sockmap_listen		# no listen socket supportin SOCKMAP
 sockopt_sk
+stacktrace_build_id	# v5.9+
 stack_var_off		# v5.12+
 task_local_storage	# v5.12+
 tcp_hdr_options		# v5.10+, new TCP header options feature in BPF

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -15,7 +15,7 @@ ${VMTEST_ROOT}/build_pahole.sh travis-ci/vmtest/pahole
 travis_fold start install_clang "Installing Clang/LLVM"
 
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
+sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
 sudo apt-get update
 sudo apt-get install -y clang-13 lld-13 llvm-13
 


### PR DESCRIPTION
@anakryiko Seems like adding libguestfs for https://github.com/libbpf/libbpf/pull/204 requires moving to focal, because bionic libguestfs uses bionic qemu-system-s390x, which is too old for the modern s390x kernels (I remember I bumped into it during my first attempt to add s390x to the CI). I've experimented with the focal libguestfs in a separate repo, and it worked there. So I've taken your commit from https://github.com/libbpf/libbpf/pull/235 for this PR (without the pahole part) and added two fixes on top.