### PR TITLE
fix KERNEL_VERSION macro

### DIFF
--- a/src/bpf_helpers.h
+++ b/src/bpf_helpers.h
@@ -51,7 +51,7 @@
 #endif
 
 #ifndef KERNEL_VERSION
-#define KERNEL_VERSION(a,b,c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c))
+#define KERNEL_VERSION(a,b,c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c)))
 #endif
 
 /*


### PR DESCRIPTION
KERNEL_VERSION macro has mismatched parentheses which result in a problem mentioned in https://github.com/iovisor/bcc/pull/3338

This PR aims to fix that.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>