### PR TITLE
travis-ci: use default docker from Focal

### DIFF
--- a/travis-ci/managers/debian.sh
+++ b/travis-ci/managers/debian.sh
@@ -31,19 +31,6 @@ for phase in "${PHASES[@]}"; do
             info "Setup phase"
             info "Using Debian $DEBIAN_RELEASE"
 
-	    # Install Docker Engine
-            sudo apt-get update
-            sudo apt-get install \
-                apt-transport-https \
-                ca-certificates \
-                curl \
-                gnupg-agent \
-                software-properties-common
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-            sudo add-apt-repository \
-                "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-            sudo apt-get update
-            sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
             docker --version
 
             docker pull debian:$DEBIAN_RELEASE


### PR DESCRIPTION
Signed-off-by: Andrii Nakryiko <andrii@kernel.org>