### PR TITLE
vmtest: use clang-14 as latest nightly

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -8,7 +8,7 @@ travis_fold start prepare_selftests "Building selftests"
 
 sudo apt-get -y install python-docutils # for rst2man
 
-LLVM_VER=13
+LLVM_VER=14
 LIBBPF_PATH="${REPO_ROOT}"
 REPO_PATH="travis-ci/vmtest/bpf-next"
 

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -17,7 +17,7 @@ travis_fold start install_clang "Installing Clang/LLVM"
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
 sudo apt-get update
-sudo apt-get install -y clang-13 lld-13 llvm-13
+sudo apt-get install -y clang-14 lld-14 llvm-14
 
 travis_fold end install_clang
 


### PR DESCRIPTION
Seems like nightly got switched tonight to clang-14.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>