### PR TITLE
vmtests: libelf-dev should be already installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,12 @@ stages:
 jobs:
     include:
         - stage: Builds & Tests
-          name: Kernel LATEST + selftests
+          name: Kernel 5.5.0 + selftests
+          language: bash
+          env: KERNEL=5.5.0
+          script:  $CI_ROOT/vmtest/run_vmtest.sh || travis_terminate 1
+
+        - name: Kernel LATEST + selftests
           language: bash
           env: KERNEL=LATEST
           script:  $CI_ROOT/vmtest/run_vmtest.sh || travis_terminate 1
@@ -44,11 +49,6 @@ jobs:
         - name: Kernel 4.9.0 + selftests
           language: bash
           env: KERNEL=4.9.0
-          script:  $CI_ROOT/vmtest/run_vmtest.sh || travis_terminate 1
-
-        - name: Kernel 5.5.0 + selftests
-          language: bash
-          env: KERNEL=5.5.0
           script:  $CI_ROOT/vmtest/run_vmtest.sh || travis_terminate 1
 
         - name: Debian Build

--- a/travis-ci/managers/ubuntu.sh
+++ b/travis-ci/managers/ubuntu.sh
@@ -3,11 +3,8 @@ set -eux
 
 RELEASE="focal"
 
-echo "deb-src http://archive.ubuntu.com/ubuntu/ $RELEASE main restricted universe multiverse" >>/etc/apt/sources.list
-
 apt-get update
-apt-get -y build-dep libelf-dev
-apt-get install -y libelf-dev pkg-config
+apt-get install -y pkg-config
 
 source "$(dirname $0)/travis_wait.bash"
 

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -17,7 +17,9 @@ travis_fold start install_clang "Installing Clang/LLVM"
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
 sudo apt-get update
-sudo apt-get install -y clang-13 lld-13 llvm-13
+sudo apt-get install --allow-downgrades -y libc6=2.31-0ubuntu9.2
+sudo aptitude install -y g++ libelf-dev
+sudo aptitude install -y clang-13 lld-13 llvm-13
 
 travis_fold end install_clang
 


### PR DESCRIPTION
Drop explicit libelf-dev install command, as it should be pre-installed by
Travis CI already, according to .travis.yaml.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>