### PR TITLE
Add coverity workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,30 @@
+name: libbpf-ci-coverity
+
+on:
+  schedule:
+    - cron:  '0 18 * * *'
+
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    name: Coverity
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup
+      - name: Run coverity
+        run: |
+          echo ::group::Setup CI env
+          source /tmp/ci_setup
+          export COVERITY_SCAN_NOTIFICATION_EMAIL="${AUTHOR_EMAIL}"
+          export COVERITY_SCAN_BRANCH_PATTERN=${GITHUB_REF##refs/*/}
+          export TRAVIS_BRANCH=${COVERITY_SCAN_BRANCH_PATTERN}
+          echo ::endgroup
+          scripts/coverity.sh
+        env:
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          COVERITY_SCAN_PROJECT_NAME: libbpf
+          COVERITY_SCAN_BUILD_COMMAND_PREPEND: 'cd src/'
+          COVERITY_SCAN_BUILD_COMMAND: 'make'
+      - name: SCM log
+        run: cat /home/runner/work/libbpf/libbpf/src/cov-int/scm_log.txt

--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -423,9 +423,10 @@ fi
 echo "${setup_script}" | sudo tee "$mnt/etc/rcS.d/S50-run-tests" > /dev/null
 sudo chmod 755 "$mnt/etc/rcS.d/S50-run-tests"
 
+fold_shutdown="$(travis_fold start shutdown)"
 poweroff_script="#!/bin/sh
 
-echo travis_fold:start:shutdown
+echo ${fold_shutdown}
 echo -e '\033[1;33mShutdown\033[0m\n'
 
 poweroff"


### PR DESCRIPTION
I've added COVERITY_SCAN_TOKEN and this change should work.
Seems like we have limit for scans and now it fails with:
"Coverity Scan analysis NOT authorized until Wed, 16 Jun 2021 01:04:24 +0000 UTC."
https://github.com/tsipa/libbpf/runs/2833993416?check_suite_focus=true

but previously i've got green builds: https://github.com/tsipa/libbpf/actions/runs/940726229

also removed 
"echo travis_fold:start:shutdown"
which doesn't have an end and it's not clear what is the purpose of this. If you know that it's intentionally put here pls let me know - i'll rework this part.