### PR TITLE
Add ondemand vmtest workflow

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -2,19 +2,34 @@ name: 'vmtest'
 description: 'Build + run vmtest'
 inputs:
   kernel:
-    description: 'kernel or LATEST'
+    description: 'kernel version or LATEST'
     required: true
     default: 'LATEST'
+  kernel-rev:
+    description: 'CHECKPOINT or rev/tag/branch'
+    required: true
+    default: 'CHECKPOINT'
+  kernel-origin:
+    description: 'kernel repo'
+    required: true
+    default: 'https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git'
   pahole:
-    description: 'pahole branch'
+    description: 'pahole rev/tag/branch'
     required: true
     default: 'master'
+  pahole-origin:
+    description: 'pahole repo'
+    required: true
+    default: 'https://git.kernel.org/pub/scm/devel/pahole/pahole.git'
 runs:
   using: "composite"
   steps:
     - run: |
         source /tmp/ci_setup
         export KERNEL=${{ inputs.kernel }}
+        export KERNEL_BRANCH=${{ inputs.kernel-rev }}
+        export KERNEL_ORIGIN=${{ inputs.kernel-origin }}
         export PAHOLE_BRANCH=${{ inputs.pahole }}
+        export PAHOLE_ORIGIN=${{ inputs.pahole-origin }}
         $CI_ROOT/vmtest/run_vmtest.sh
       shell: bash

--- a/.github/workflows/ondemand.yml
+++ b/.github/workflows/ondemand.yml
@@ -1,0 +1,36 @@
+name: ondemand
+
+on:
+  workflow_dispatch:
+    inputs:
+      kernel-origin:
+        description: 'git repo for linux kernel'
+        default: 'https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git'
+        required: true
+      kernel-rev:
+        description: 'rev/tag/branch for linux kernel'
+        default: "master"
+        required: true
+      pahole-origin:
+        description: 'git repo for pahole'
+        default: 'https://git.kernel.org/pub/scm/devel/pahole/pahole.git'
+        required: true
+      pahole-rev:
+        description: 'ref/tag/branch for pahole'
+        default: "master"
+        required: true
+
+jobs:
+  vmtest:
+    runs-on: ubuntu-latest
+    name: vmtest with customized pahole/Kernel
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/vmtest
+        with:
+          kernel: 'LATEST'
+          kernel-rev: ${{ github.event.inputs.kernel-rev }}
+          kernel-origin: ${{ github.event.inputs.kernel-origin }}
+          pahole: ${{ github.event.inputs.pahole-rev }}
+          pahole-origin: ${{ github.event.inputs.pahole-origin }}

--- a/travis-ci/vmtest/build_pahole.sh
+++ b/travis-ci/vmtest/build_pahole.sh
@@ -4,12 +4,12 @@ set -eu
 
 source $(cd $(dirname $0) && pwd)/helpers.sh
 
-travis_fold start build_pahole "Building pahole"
-
 CWD=$(pwd)
 REPO_PATH=$1
-PAHOLE_ORIGIN=https://git.kernel.org/pub/scm/devel/pahole/pahole.git
+PAHOLE_ORIGIN=${PAHOLE_ORIGIN:-https://git.kernel.org/pub/scm/devel/pahole/pahole.git}
 PAHOLE_BRANCH=${PAHOLE_BRANCH:-master}
+
+travis_fold start build_pahole "Building pahole ${PAHOLE_ORIGIN} ${PAHOLE_BRANCH}"
 
 mkdir -p ${REPO_PATH}
 cd ${REPO_PATH}

--- a/travis-ci/vmtest/checkout_latest_kernel.sh
+++ b/travis-ci/vmtest/checkout_latest_kernel.sh
@@ -8,12 +8,22 @@ CWD=$(pwd)
 LIBBPF_PATH=$(pwd)
 REPO_PATH=$1
 
-BPF_NEXT_ORIGIN=https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git
-LINUX_SHA=$(cat ${LIBBPF_PATH}/CHECKPOINT-COMMIT)
-SNAPSHOT_URL=https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/snapshot/bpf-next-${LINUX_SHA}.tar.gz
+KERNEL_ORIGIN=${KERNEL_ORIGIN:-https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git}
+KERNEL_BRANCH=${KERNEL_BRANCH:-CHECKPOINT}
+if [[ "${KERNEL_BRANCH}" = 'CHECKPOINT' ]]; then
+  echo "using CHECKPOINT sha1"
+  LINUX_SHA=$(cat ${LIBBPF_PATH}/CHECKPOINT-COMMIT)
+else
+  echo "using ${KERNEL_BRANCH} sha1"
+  LINUX_SHA=$(git ls-remote ${KERNEL_ORIGIN} ${KERNEL_BRANCH} | awk '{print $1}')
+fi
+SNAPSHOT_URL=${KERNEL_ORIGIN}/snapshot/bpf-next-${LINUX_SHA}.tar.gz
 
 echo REPO_PATH = ${REPO_PATH}
+
+echo KERNEL_ORIGIN = ${KERNEL_ORIGIN}
 echo LINUX_SHA = ${LINUX_SHA}
+echo SNAPSHOT_URL = ${SNAPSHOT_URL}
 
 if [ ! -d "${REPO_PATH}" ]; then
 	echo
@@ -29,7 +39,7 @@ if [ ! -d "${REPO_PATH}" ]; then
 		mkdir -p $(basename ${REPO_PATH})
 		cd $(basename ${REPO_PATH})
 		git init
-		git remote add bpf-next ${BPF_NEXT_ORIGIN}
+		git remote add bpf-next ${KERNEL_ORIGIN}
 		# try shallow clone first
 		git fetch --depth 32 bpf-next
 		# check if desired SHA exists

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -24,7 +24,7 @@ sudo aptitude install -y clang-13 lld-13 llvm-13
 travis_fold end install_clang
 
 # Build selftests (and latest kernel, if necessary)
-KERNEL="${KERNEL}" ${VMTEST_ROOT}/prepare_selftests.sh travis-ci/vmtest/bpf-next
+${VMTEST_ROOT}/prepare_selftests.sh travis-ci/vmtest/bpf-next
 
 # Escape whitespace characters.
 setup_cmd=$(sed 's/\([[:space:]]\)/\\\1/g' <<< "${VMTEST_SETUPCMD}")


### PR DESCRIPTION
Make it possible to start a libbpf vmtest with supplied pahole / linux repo/branch.

Cavet: it will always use latest.config for any supplied kernel