### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Some major Linux distributions come with kernel BTF already built in:
   - RHEL 8.2+
   - OpenSUSE Tumbleweed (in the next release, as of 2020-06-04)
   - Arch Linux (from kernel 5.7.1.arch1-1)
-  - Manjaro
+  - Manjaro (from kernel 5.4 if compiled after 2021-06-18)
   - Ubuntu 20.10
   - Debian 11 (amd64/arm64)
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Some major Linux distributions come with kernel BTF already built in:
   - RHEL 8.2+
   - OpenSUSE Tumbleweed (in the next release, as of 2020-06-04)
   - Arch Linux (from kernel 5.7.1.arch1-1)
+  - Manjaro
   - Ubuntu 20.10
   - Debian 11 (amd64/arm64)
 


### PR DESCRIPTION
Manjaro is a popular and friendly Arch based distro. Recently they also enabled the BTF support: https://forum.manjaro.org/t/co-re-support-in-kernel/46134/19

I can confirm that:
[user@pc ~]$ uname -a
Linux pc 5.12.16-1-MANJARO #1 SMP PREEMPT Sun Jul 11 13:23:34 UTC 2021 x86_64 GNU/Linux
[user@pc ~]$ ls -la /sys/kernel/btf/vmlinux
-r--r--r-- 1 root root 4226769 jul   17 15.27 /sys/kernel/btf/vmlinux