### PR TITLE
ci: bump nightly Clang/LLVM version to 14

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -8,7 +8,7 @@ travis_fold start prepare_selftests "Building selftests"
 
 sudo apt-get -y install python-docutils # for rst2man
 
-LLVM_VER=13
+LLVM_VER=14
 LIBBPF_PATH="${REPO_ROOT}"
 REPO_PATH="travis-ci/vmtest/bpf-next"
 

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -19,7 +19,7 @@ sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal mai
 sudo apt-get update
 sudo apt-get install --allow-downgrades -y libc6=2.31-0ubuntu9.2
 sudo aptitude install -y g++ libelf-dev
-sudo aptitude install -y clang-13 lld-13 llvm-13
+sudo aptitude install -y clang-14 lld-14 llvm-14
 
 travis_fold end install_clang
 


### PR DESCRIPTION
CI started to fail with missing clang-13 warning. Bump the version to 14.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>