### PR TITLE
Fix text grouping issue on github actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,6 +18,6 @@ runs:
         echo export REPO_ROOT=$GITHUB_WORKSPACE >> /tmp/ci_setup
         echo export CI_ROOT=$REPO_ROOT/travis-ci >> /tmp/ci_setup
         echo export VMTEST_ROOT=$CI_ROOT/vmtest >> /tmp/ci_setup
-        echo 'echo ::endgroup' >> /tmp/ci_setup
+        echo 'echo ::endgroup::' >> /tmp/ci_setup
       shell: bash
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,7 +19,7 @@ jobs:
           export COVERITY_SCAN_NOTIFICATION_EMAIL="${AUTHOR_EMAIL}"
           export COVERITY_SCAN_BRANCH_PATTERN=${GITHUB_REF##refs/*/}
           export TRAVIS_BRANCH=${COVERITY_SCAN_BRANCH_PATTERN}
-          echo ::endgroup
+          echo ::endgroup::
           scripts/coverity.sh
         env:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/travis-ci/managers/debian.sh
+++ b/travis-ci/managers/debian.sh
@@ -38,12 +38,14 @@ for phase in "${PHASES[@]}"; do
             $DOCKER_RUN -v $REPO_ROOT:/build:rw \
                         -w /build --privileged=true --name $CONT_NAME \
                         -dit --net=host debian:$DEBIAN_RELEASE /bin/bash
+            echo -e "::group::Build Env Setup"
             docker_exec bash -c "echo deb-src http://deb.debian.org/debian $DEBIAN_RELEASE main >>/etc/apt/sources.list"
             docker_exec apt-get -y update
             docker_exec apt-get -y install aptitude
             docker_exec aptitude -y build-dep libelf-dev
             docker_exec aptitude -y install libelf-dev
             docker_exec aptitude -y install "${ADDITIONAL_DEPS[@]}"
+            echo -e "::endgroup::"
             ;;
         RUN|RUN_CLANG|RUN_GCC10|RUN_ASAN|RUN_CLANG_ASAN|RUN_GCC10_ASAN)
             if [[ "$phase" = *"CLANG"* ]]; then
@@ -62,7 +64,7 @@ for phase in "${PHASES[@]}"; do
             docker_exec mkdir build install
             docker_exec ${CC:-cc} --version
             info "build"
-	    docker_exec make -j$((4*$(nproc))) CFLAGS="${CFLAGS}" -C ./src -B OBJDIR=../build
+            docker_exec make -j$((4*$(nproc))) CFLAGS="${CFLAGS}" -C ./src -B OBJDIR=../build
             info "ldd build/libbpf.so:"
             docker_exec ldd build/libbpf.so
             if ! docker_exec ldd build/libbpf.so | grep -q libelf; then

--- a/travis-ci/vmtest/helpers.sh
+++ b/travis-ci/vmtest/helpers.sh
@@ -17,7 +17,7 @@ travis_fold() {
         line="$line - ${YELLOW}$3${NOCOLOR}"
       fi
     else
-      line="::endgroup"
+      line="::endgroup::"
     fi
     echo -e "$line"
   fi


### PR DESCRIPTION
github action grouping is broken because we were outputting "::endgroup" where
it needs "::endgroup::". This patch also added some additional grouping around
container setup phase, making output easier to read.