### PR TITLE
Add a test step to produce a minimal binary using libbpf.

### DIFF
--- a/travis-ci/managers/test_compile.sh
+++ b/travis-ci/managers/test_compile.sh
@@ -12,11 +12,3 @@ EOF
 
 # static linking
 ${CC:-cc} ${CFLAGS} -o main -I./install/usr/include main.c ./build/libbpf.a -lelf -lz
-
-# shared linking
-${CC:-cc} ${CFLAGS} -o main_shared -I./install/usr/include main.c -L./install/usr/lib64 -L./install/usr/lib -lbpf
-ldd main_shared
-if ! ldd main_shared | grep -q libbpf; then
-    echo "FAIL: No reference to libbpf.so in main!"
-    exit 1
-fi

--- a/travis-ci/managers/test_compile.sh
+++ b/travis-ci/managers/test_compile.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euox pipefail
+
+CFLAGS=${CFLAGS:-}
+
+cat << EOF > main.c
+#include <bpf/libbpf.h>
+int main() {
+  return bpf_object__open(0) < 0;
+}
+EOF
+
+# static linking
+${CC:-cc} ${CFLAGS} -o main -I./install/usr/include main.c ./build/libbpf.a -lelf -lz
+
+# shared linking
+${CC:-cc} ${CFLAGS} -o main_shared -I./install/usr/include main.c -L./install/usr/lib64 -L./install/usr/lib -lbpf
+ldd main_shared
+if ! ldd main_shared | grep -q libbpf; then
+    echo "FAIL: No reference to libbpf.so in main!"
+    exit 1
+fi

--- a/travis-ci/managers/ubuntu.sh
+++ b/travis-ci/managers/ubuntu.sh
@@ -20,4 +20,4 @@ if ! ldd build/libbpf.so | grep -q libelf; then
     exit 1
 fi
 make -j$((4*$(nproc))) -C src OBJDIR=../build DESTDIR=../install install
-rm -rf build install
+CFLAGS=${CFLAGS} $(dirname $0)/test_compile.sh


### PR DESCRIPTION
This patch adds a test step to link a minimal program to libbpf library produced,
making sure that the library works.