### PR TITLE
ci: make CI build log less verbose

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -30,7 +30,7 @@ make \
 	VMLINUX_BTF="${VMLINUX_BTF}" \
 	VMLINUX_H=${VMLINUX_H} \
 	-C "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
-	-j $((4*$(nproc)))
+	-j $((4*$(nproc))) >/dev/null
 mkdir ${LIBBPF_PATH}/selftests
 cp -R "${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf" \
 	${LIBBPF_PATH}/selftests

--- a/travis-ci/vmtest/checkout_latest_kernel.sh
+++ b/travis-ci/vmtest/checkout_latest_kernel.sh
@@ -32,7 +32,7 @@ if [ ! -d "${REPO_PATH}" ]; then
 	mkdir -p $(dirname "${REPO_PATH}")
 	cd $(dirname "${REPO_PATH}")
 	# attempt to fetch desired bpf-next repo snapshot
-	if wget ${SNAPSHOT_URL} && tar xf bpf-next-${LINUX_SHA}.tar.gz ; then
+	if wget -nv ${SNAPSHOT_URL} && tar xf bpf-next-${LINUX_SHA}.tar.gz --totals ; then
 		mv bpf-next-${LINUX_SHA} $(basename ${REPO_PATH})
 	else
 		# but fallback to git fetch approach if that fails

--- a/travis-ci/vmtest/prepare_selftests.sh
+++ b/travis-ci/vmtest/prepare_selftests.sh
@@ -13,7 +13,7 @@ if [[ "${KERNEL}" = 'LATEST' ]]; then
 	travis_fold start build_kernel "Kernel build"
 
 	cp ${VMTEST_ROOT}/configs/latest.config .config
-	make -j $((4*$(nproc))) olddefconfig all
+	make -j $((4*$(nproc))) olddefconfig all >/dev/null
 
 	travis_fold end build_kernel
 fi


### PR DESCRIPTION
Only keep stderr output in case of errors. Having a multi-thousand-line output
isn't useful and slows down Github Actions' log view UI.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>