### PR TITLE
ci: run script to test bpftool types/options sync

### DIFF
--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -386,6 +386,15 @@ LIBBPF_PATH="${REPO_ROOT}" \
 	REPO_PATH="${REPO_PATH}" \
 	VMLINUX_BTF=${vmlinux} ${VMTEST_ROOT}/build_selftests.sh
 
+travis_fold start bpftool_checks "Running bpftool checks..."
+if [[ "${KERNEL}" = 'LATEST' ]]; then
+	"${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && \
+		echo "Consistency checks passed successfully."
+else
+	echo "Consistency checks skipped."
+fi
+travis_fold end bpftool_checks
+
 travis_fold start vm_init "Starting virtual machine..."
 
 if (( SKIPSOURCE )); then


### PR DESCRIPTION
### Consistency checks for bpftool

This PR adds a call to test_bpftool_synctypes.py to run_selftests.sh. The objective of this script is to make sure that the different parts of bpftool that should be updated on BPF UAPI changes (type lists, help messages, documentation, bash completion) do remain in sync between them, and with the UAPI headers from the kernel. The motivation to have it in the CI is to effectively make sure that new patchsets consistently update all those parts when necessary.

This PR is similar to https://github.com/kernel-patches/vmtest/pull/22.