### PR TITLE
ci: restore all temporary disabled tests

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,2 +1,1 @@
 # TEMPORARY
-tc_bpf

--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -46,6 +46,6 @@ cd libbpf/selftests/bpf
 test_progs
 
 if [[ "${KERNEL}" == 'latest' ]]; then
-	#test_maps
+	# test_maps
 	test_verifier
 fi


### PR DESCRIPTION
Upstream bpf/bpf-next should be good, so no temporary blocked tests should
remain. Also enable test_maps back. They are still occasionally flaky, but
good to have a bit more visibility into those failures.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>