### PR TITLE
Make CI tests compatible with vanilla kernel tree

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -10,7 +10,6 @@ sudo apt-get -y install python-docutils # for rst2man
 
 LLVM_VER=14
 LIBBPF_PATH="${REPO_ROOT}"
-REPO_PATH="travis-ci/vmtest/bpf-next"
 
 PREPARE_SELFTESTS_SCRIPT=${VMTEST_ROOT}/prepare_selftests-${KERNEL}.sh
 if [ -f "${PREPARE_SELFTESTS_SCRIPT}" ]; then

--- a/travis-ci/vmtest/prepare_selftests.sh
+++ b/travis-ci/vmtest/prepare_selftests.sh
@@ -4,17 +4,18 @@ set -eu
 
 source $(cd $(dirname $0) && pwd)/helpers.sh
 
-REPO_PATH=$1
+REPO_PATH=${1:-}
 
-${VMTEST_ROOT}/checkout_latest_kernel.sh ${REPO_PATH}
-cd ${REPO_PATH}
+if [[ ! -z "$REPO_PATH" ]]; then
+	${VMTEST_ROOT}/checkout_latest_kernel.sh ${REPO_PATH}
+	cd ${REPO_PATH}
+fi
 
 if [[ "${KERNEL}" = 'LATEST' ]]; then
 	travis_fold start build_kernel "Kernel build"
 
 	cp ${VMTEST_ROOT}/configs/latest.config .config
 	make -j $((4*$(nproc))) olddefconfig all >/dev/null
-
 	travis_fold end build_kernel
 fi
 

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -6,6 +6,10 @@ source $(cd $(dirname $0) && pwd)/helpers.sh
 
 VMTEST_SETUPCMD="GITHUB_WORKFLOW=${GITHUB_WORKFLOW:-} PROJECT_NAME=${PROJECT_NAME} ./${PROJECT_NAME}/travis-ci/vmtest/run_selftests.sh"
 
+# if CHECKOUT_KERNEL is 1 code will consider that kernel code lives elsewhere
+# if 0 it will consider that REPO_ROOT is a kernel tree
+CHECKOUT_KERNEL=${CHECKOUT_KERNEL:-1}
+
 echo "KERNEL: $KERNEL"
 echo
 
@@ -24,7 +28,12 @@ sudo aptitude install -y clang-14 lld-14 llvm-14
 travis_fold end install_clang
 
 # Build selftests (and latest kernel, if necessary)
-${VMTEST_ROOT}/prepare_selftests.sh travis-ci/vmtest/bpf-next
+
+if [[ "$CHECKOUT_KERNEL" == "1" ]]; then
+  ${VMTEST_ROOT}/prepare_selftests.sh travis-ci/vmtest/bpf-next
+else
+  ${VMTEST_ROOT}/prepare_selftests.sh
+fi
 
 # Escape whitespace characters.
 setup_cmd=$(sed 's/\([[:space:]]\)/\\\1/g' <<< "${VMTEST_SETUPCMD}")
@@ -32,7 +41,11 @@ setup_cmd=$(sed 's/\([[:space:]]\)/\\\1/g' <<< "${VMTEST_SETUPCMD}")
 sudo adduser "${USER}" kvm
 
 if [[ "${KERNEL}" = 'LATEST' ]]; then
-  sudo -E sudo -E -u "${USER}" "${VMTEST_ROOT}/run.sh" -b travis-ci/vmtest/bpf-next -o -d ~ -s "${setup_cmd}" ~/root.img;
+  if [[ "$CHECKOUT_KERNEL" == "1" ]]; then
+    sudo -E sudo -E -u "${USER}" "${VMTEST_ROOT}/run.sh" -b travis-ci/vmtest/bpf-next -o -d ~ -s "${setup_cmd}" ~/root.img
+  else
+    sudo -E sudo -E -u "${USER}" "${VMTEST_ROOT}/run.sh" -b "${REPO_ROOT}" -o -d ~ -s "${setup_cmd}" ~/root.img
+  fi
 else
-  sudo -E sudo -E -u "${USER}" "${VMTEST_ROOT}/run.sh" -k "${KERNEL}*" -o -d ~ -s "${setup_cmd}" ~/root.img;
+  sudo -E sudo -E -u "${USER}" "${VMTEST_ROOT}/run.sh" -k "${KERNEL}*" -o -d ~ -s "${setup_cmd}" ~/root.img
 fi


### PR DESCRIPTION
This is required to migrate kernel-patches CI to use this code
instead of fork.

The second part of this change is here https://github.com/tsipa/vmtest/commit/400feb961c06f0f7dacff6e8460620bf3fab1e53
as-is it only works to demonstrate that actions and bash code can be re-used between these two projects. The actual implementation is still to be done.