### PR TITLE
Add enum to be displayed in documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,40 +12,40 @@ libbpf.h
 --------
 .. doxygenfile:: libbpf.h
    :project: libbpf
-   :sections: func define public-type
+   :sections: func define public-type enum
 
 bpf.h
 -----
 .. doxygenfile:: bpf.h
    :project: libbpf
-   :sections: func define public-type
+   :sections: func define public-type enum
 
 btf.h
 -----
 .. doxygenfile:: btf.h
    :project: libbpf
-   :sections: func define public-type
+   :sections: func define public-type enum
 
 xsk.h
 -----
 .. doxygenfile:: xsk.h
    :project: libbpf
-   :sections: func define public-type
+   :sections: func define public-type enum
 
 bpf_tracing.h
 -------------
 .. doxygenfile:: bpf_tracing.h
    :project: libbpf
-   :sections: func define public-type
+   :sections: func define public-type enum
 
 bpf_core_read.h
 ---------------
 .. doxygenfile:: bpf_core_read.h
    :project: libbpf
-   :sections: func define public-type
+   :sections: func define public-type enum
 
 bpf_endian.h
 ------------
 .. doxygenfile:: bpf_endian.h
    :project: libbpf
-   :sections: func define public-type
+   :sections: func define public-type enum


### PR DESCRIPTION
This adds the enums in the header files to be displayed on libbpf.readthedocs.org

Follow up question to this - is everything in the headers a public facing API, and everything in c files private? Is that how things are separated?

Signed-off-by: grantseltzer <grantseltzer@gmail.com>