### PR TITLE
ci: use -a/-d with exact string match for black/whitelisting

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -7,12 +7,12 @@ source $(cd $(dirname $0) && pwd)/helpers.sh
 test_progs() {
 	if [[ "${KERNEL}" != '4.9.0' ]]; then
 		travis_fold start test_progs "Testing test_progs"
-		./test_progs ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST}
+		./test_progs ${BLACKLIST:+-d$BLACKLIST} ${WHITELIST:+-a$WHITELIST}
 		travis_fold end test_progs
 	fi
 
 	travis_fold start test_progs-no_alu32 "Testing test_progs-no_alu32"
-	./test_progs-no_alu32 ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST}
+	./test_progs-no_alu32 ${BLACKLIST:+-d$BLACKLIST} ${WHITELIST:+-a$WHITELIST}
 	travis_fold end test_progs-no_alu32
 }
 


### PR DESCRIPTION
Doing substring matches allows accidental new tests to be enabled,
when they are not supposed to be. E.g., whitelisting "xdp" allows new
"xdpwall" test on 5.5.0, which wasn't supposed to happen.

Cc: Yucong Sun <fallentree@fb.com>
Signed-off-by: Andrii Nakryiko <andrii@kernel.org>