### PR TITLE
[ci] skip forks

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   coverity:
     runs-on: ubuntu-latest
+    if: github.repository == 'libbpf/libbpf'
     name: Coverity
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
[coverity] skip forks

to stop GitHub from sending notifications about failed attemtps
to run the Coverity workflow without `COVERITY_SCAN_TOKEN` like
https://github.com/evverx/libbpf-fork/actions/runs/1364759947