### PR TITLE
sync: fix comment for commit_signature() (subject instead of hash)

### DIFF
--- a/scripts/sync-kernel.sh
+++ b/scripts/sync-kernel.sh
@@ -74,7 +74,7 @@ commit_desc()
 }
 
 # Create commit single-line signature, which consists of:
-# - full commit hash
+# - full commit subject
 # - author date in ISO8601 format
 # - full commit body with newlines replaced with vertical bars (|)
 # - shortstat appended at the end


### PR DESCRIPTION
The `commit_signature()` function does not use the hash of the commit, which typically differs between the kernel repo and the mirrored version, but the subject for this commit. Fix the comment accordingly.
