### PR TITLE
sync: remove redundant test on `$BPF_BRANCH`

### DIFF
--- a/scripts/sync-kernel.sh
+++ b/scripts/sync-kernel.sh
@@ -17,7 +17,7 @@ BPF_BRANCH=${3-""}
 BASELINE_COMMIT=${BPF_NEXT_BASELINE:-$(cat ${LIBBPF_REPO}/CHECKPOINT-COMMIT)}
 BPF_BASELINE_COMMIT=${BPF_BASELINE:-$(cat ${LIBBPF_REPO}/BPF-CHECKPOINT-COMMIT)}
 
-if [ -z "${LIBBPF_REPO}" ] || [ -z "${LINUX_REPO}" ] || [ -z "${BPF_BRANCH}" ]; then
+if [ -z "${LIBBPF_REPO}" ] || [ -z "${LINUX_REPO}" ]; then
 	echo "Error: libbpf or linux repos are not specified"
 	usage
 fi


### PR DESCRIPTION
The sync-kernel.sh script has two consecutive tests for `$BPF_BRANCH` being provided by the user (and so the second one can currently never fail). Looking at the error message displayed in each case, we want to keep the second one. Let's remove the first check.
