### PR TITLE
ci: account for bpftool check results, print a summary of all tests

### DIFF
--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -475,12 +475,11 @@ guestfish --remote \
 	upload "$tmp" /etc/rcS.d/S50-run-tests : \
 	chmod 755 /etc/rcS.d/S50-run-tests
 
-fold_shutdown="$(travis_fold start shutdown)"
+fold_shutdown="$(travis_fold start shutdown Shutdown)"
 cat <<HERE >"$tmp"
 #!/bin/sh
 
-echo ${fold_shutdown}
-echo -e '\033[1;33mShutdown\033[0m\n'
+echo -e '${fold_shutdown}'
 
 poweroff
 HERE


### PR DESCRIPTION
This is the libbpf port of the PR for the kernel CI, at https://github.com/kernel-patches/vmtest/pull/44.

Original PR description says:

> The bpftool checks work as expected when the CI runs, except that they do not set any error status code for the script on error, which means that the failures are lost among the logs and not reported in a clear way to the reviewers.
>
> Let's account for the status of bpftool checks when exiting from run.sh
>
> Let's also create a summary for the different group tests, at the end of the test logs, under the folded sections. This summary may be extended in the future with a more detailed overview of the tests running in the VM.
