### PR TITLE
Split CI results per group of selftests in final summary

### DIFF
--- a/travis-ci/vmtest/helpers.sh
+++ b/travis-ci/vmtest/helpers.sh
@@ -24,3 +24,23 @@ travis_fold() {
 }
 
 ARCH=$(uname -m)
+
+__print() {
+  local TITLE=""
+  if [[ -n $2 ]]; then
+      TITLE=" title=$2"
+  fi
+  echo "::$1${TITLE}::$3"
+}
+
+# $1 - title
+# $2 - message
+print_error() {
+  __print error $1 $2
+}
+
+# $1 - title
+# $2 - message
+print_notice() {
+  __print notice $1 $2
+}

--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -301,10 +301,10 @@ if [[ $SKIPIMG -eq 0 && ! -v ROOTFSVERSION ]]; then
 	ROOTFSVERSION="$(newest_rootfs_version)"
 fi
 
+travis_fold start vmlinux_setup "Preparing Linux image"
+
 echo "Kernel release: $KERNELRELEASE" >&2
 echo
-
-travis_fold start vmlinux_setup "Preparing Linux image"
 
 if (( SKIPIMG )); then
 	echo "Not extracting root filesystem" >&2
@@ -475,12 +475,17 @@ set -eux
 
 echo 'Running setup commands'
 ${setup_envvars}
-set +e; ${setup_cmd}; exitstatus=\$?; set -e
+set +e
+${setup_cmd}; exitstatus=\$?
+echo -e '$(travis_fold start collect_status "Collect status")'
+set -e
 # If setup command did not write its exit status to /exitstatus, do it now
 if [[ -s /exitstatus ]]; then
 	echo setup_cmd:\$exitstatus > /exitstatus
 fi
 chmod 644 /exitstatus
+echo -e '$(travis_fold end collect_status)'
+echo -e '$(travis_fold start shutdown Shutdown)'
 HERE
 fi
 
@@ -488,11 +493,8 @@ guestfish --remote \
 	upload "$tmp" /etc/rcS.d/S50-run-tests : \
 	chmod 755 /etc/rcS.d/S50-run-tests
 
-fold_shutdown="$(travis_fold start shutdown Shutdown)"
 cat <<HERE >"$tmp"
 #!/bin/sh
-
-echo -e '${fold_shutdown}'
 
 poweroff
 HERE

--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -420,9 +420,9 @@ if [[ "${KERNEL}" = 'LATEST' ]]; then
 	"${REPO_ROOT}/${REPO_PATH}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && true
 	test_results["bpftool"]=$?
 	if [[ ${test_results["bpftool"]} -eq 0 ]]; then
-		echo "::notice title=bpftool_checks::bpftool checks passed successfully."
+		print_notice bpftool_checks "bpftool checks passed successfully."
 	else
-		echo "::error title=bpftool_checks::bpftool checks returned ${test_results["bpftool"]}."
+		print_error bpftool_checks "bpftool checks returned ${test_results["bpftool"]}."
 	fi
 else
 	echo "Consistency checks skipped."

--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source $(cd $(dirname $0) && pwd)/helpers.sh
 
+STATUS_FILE=/exitstatus
+
 read_lists() {
 	(for path in "$@"; do
 		if [[ -s "$path" ]]; then
@@ -15,24 +17,31 @@ read_lists() {
 test_progs() {
 	if [[ "${KERNEL}" != '4.9.0' ]]; then
 		travis_fold start test_progs "Testing test_progs"
-		./test_progs ${BLACKLIST:+-d$BLACKLIST} ${WHITELIST:+-a$WHITELIST}
+		# "&& true" does not change the return code (it is not executed
+		# if the Python script fails), but it prevents exiting on a
+		# failure due to the "set -e".
+		./test_progs ${BLACKLIST:+-d$BLACKLIST} ${WHITELIST:+-a$WHITELIST} && true
+		echo "test_progs:$?" >> "${STATUS_FILE}"
 		travis_fold end test_progs
 	fi
 
 	travis_fold start test_progs-no_alu32 "Testing test_progs-no_alu32"
-	./test_progs-no_alu32 ${BLACKLIST:+-d$BLACKLIST} ${WHITELIST:+-a$WHITELIST}
+	./test_progs-no_alu32 ${BLACKLIST:+-d$BLACKLIST} ${WHITELIST:+-a$WHITELIST} && true
+	echo "test_progs-no_alu32:$?" >> "${STATUS_FILE}"
 	travis_fold end test_progs-no_alu32
 }
 
 test_maps() {
 	travis_fold start test_maps "Testing test_maps"
-	./test_maps
+	./test_maps && true
+	echo "test_maps:$?" >> "${STATUS_FILE}"
 	travis_fold end test_maps
 }
 
 test_verifier() {
 	travis_fold start test_verifier "Testing test_verifier"
-	./test_verifier
+	./test_verifier && true
+	echo "test_verifier:$?" >> "${STATUS_FILE}"
 	travis_fold end test_verifier
 }
 

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -35,10 +35,12 @@ else
   ${VMTEST_ROOT}/prepare_selftests.sh
 fi
 
+travis_fold start adduser_to_kvm "Add user ${USER}"
+sudo adduser "${USER}" kvm
+travis_fold stop adduser_to_kvm
+
 # Escape whitespace characters.
 setup_cmd=$(sed 's/\([[:space:]]\)/\\\1/g' <<< "${VMTEST_SETUPCMD}")
-
-sudo adduser "${USER}" kvm
 
 if [[ "${KERNEL}" = 'LATEST' ]]; then
   if [[ "$CHECKOUT_KERNEL" == "1" ]]; then


### PR DESCRIPTION
Libbpf port of https://github.com/kernel-patches/vmtest/pull/47

One difference is that we don't write bpftool result to `/exitstatus`, we keep it in a variable instead (I'm not familiar with guestfish and didn't want to bother writing to the file).
