### PR TITLE
ci: whitelist legacy_printk tests on 4.9 and 5.5

### DIFF
--- a/travis-ci/vmtest/configs/whitelist/WHITELIST-4.9.0
+++ b/travis-ci/vmtest/configs/whitelist/WHITELIST-4.9.0
@@ -2,6 +2,7 @@
 core_retro
 cpu_mask
 hashmap
+legacy_printk
 perf_buffer
 section_names
 

--- a/travis-ci/vmtest/configs/whitelist/WHITELIST-5.5.0
+++ b/travis-ci/vmtest/configs/whitelist/WHITELIST-5.5.0
@@ -18,6 +18,7 @@ global_data_init
 global_func_args
 hashmap
 l4lb_all
+legacy_printk
 linked_funcs
 linked_maps
 map_lock


### PR DESCRIPTION
legacy_printk selftests is specially designed to be runnable on old
kernels and validate libbpf's bpf_trace_printk-related macros. Run them
in CI.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>