### PR TITLE
ci: fix test on `/exitstatus` existence and size

### DIFF
--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -480,7 +480,7 @@ ${setup_cmd}; exitstatus=\$?
 echo -e '$(travis_fold start collect_status "Collect status")'
 set -e
 # If setup command did not write its exit status to /exitstatus, do it now
-if [[ -s /exitstatus ]]; then
+if [[ ! -s /exitstatus ]]; then
 	echo setup_cmd:\$exitstatus > /exitstatus
 fi
 chmod 644 /exitstatus


### PR DESCRIPTION
The condition for the test is incorrect, we want to add a default exit status if the file is empty. But [[ -s file ]] returns true if the file exists and has a size greater than zero. Let's reverse the condition.

[ Apologies for the silly mistake, previous PR was merged before I had time to check the result of the latest CI run :/ ]

Fixes: #412
