### PR TITLE
ci: upgrade s390x runner to v2.285.0

### DIFF
--- a/travis-ci/vmtest/s390x-self-hosted-builder/README.md
+++ b/travis-ci/vmtest/s390x-self-hosted-builder/README.md
@@ -62,8 +62,8 @@ $ sudo systemctl restart actions-runner-libbpf
 The `actions-runner-libbpf` service stores various temporary data, such as
 runner  registration information, work directories and logs, in the
 `actions-runner-libbpf` volume. In order to remove it and start from scratch,
-e.g. when switching the runner to a different repository, use the following
-commands:
+e.g. when upgrading the runner or switching it to a different repository, use
+the following commands:
 
 ```
 $ sudo systemctl stop actions-runner-libbpf

--- a/travis-ci/vmtest/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
+++ b/travis-ci/vmtest/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
@@ -33,13 +33,14 @@ RUN ln -fs /etc/resolv.conf /usr/x86_64-linux-gnu/etc/
 ENV QEMU_LD_PREFIX=/usr/x86_64-linux-gnu
 
 # amd64 Github Actions Runner.
+ARG version=2.285.0
 RUN useradd -m actions-runner
 RUN echo "actions-runner ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 RUN echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >>/etc/sudoers
 USER actions-runner
 ENV USER=actions-runner
 WORKDIR /home/actions-runner
-RUN curl -L https://github.com/actions/runner/releases/download/v2.283.2/actions-runner-linux-x64-2.283.2.tar.gz | tar -xz
+RUN curl -L https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-x64-${version}.tar.gz | tar -xz
 VOLUME /home/actions-runner
 
 # Scripts.


### PR DESCRIPTION
This is needed for composite actions with conditional steps.

Fixes #416.

Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>