### PR TITLE
Add documentation for error checking in API doc

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,7 +6,48 @@
 
 
 LIBBPF API
-==================
+==========
+
+Error Handling
+--------------
+
+When libbpf is used in "libbpf 1.0 mode", API functions can return errors in one of two ways.
+
+You can set "libbpf 1.0" mode with the following line:
+
+.. code-block::
+
+    libbpf_set_strict_mode(LIBBPF_STRICT_DIRECT_ERRS | LIBBPF_STRICT_CLEAN_PTRS);
+
+If the function returns an error code directly, it uses 0 to indicate success
+and a negative error code to indicate what caused the error. In this case the
+error code should be checked directly from the return, you do not need to check
+errno. 
+
+For example:
+
+.. code-block::
+
+    err = some_libbpf_api_with_error_return(...);
+    if (err < 0) {
+        /* Handle error accordingly */
+    }
+
+If the function returns a pointer, it will return NULL to indicate there was 
+an error. In this case errno should be checked for the error code.
+
+For example:
+
+.. code-block::
+
+    ptr = some_libbpf_api_returning_ptr();
+    if (!ptr) {
+        if (errno = -EINVAL) {
+           /* handle EINVAL error */
+        } else if (errno == E2BIG) { /* note no minus sign */
+           /* handle E2BIG error */
+        }
+    }
 
 libbpf.h
 --------


### PR DESCRIPTION
The API doc only exists in the github repo, so opened the PR here instead of the mailing list.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>