### PR TITLE
travis-ci/rootfs: Fix mount(8) invocation for Arch Linux

### DIFF
--- a/travis-ci/rootfs/mkrootfs_tweak.sh
+++ b/travis-ci/rootfs/mkrootfs_tweak.sh
@@ -25,7 +25,7 @@ set -eux
 /bin/mount proc /proc -t proc
 
 # Mount devtmpfs if not mounted
-if [[ -z $(/bin/mount -l -t devtmpfs) ]]; then
+if [[ -z $(/bin/mount -t devtmpfs) ]]; then
 	/bin/mount devtmpfs /dev -t devtmpfs
 fi
 


### PR DESCRIPTION
Given that the rootfs for Arch Linux uses the busybox variant of
mount(8), the `-l` doesn't exist on that binary and gives the following
error msg with version v1.34.1 of busybox when invoking
mkrootfs_arch.sh:

```
...
[    0.781471] random: fast init done
starting pid 72, tty '': '/etc/init.d/rcS'
+ for path in /etc/rcS.d/S*
+ '[' -x /etc/rcS.d/S10-mount ']'
+ /etc/rcS.d/S10-mount
+ /bin/mount proc /proc -t proc
++ /bin/mount -l -t devtmpfs
/bin/mount: unrecognized option: l
...
```

This prevented me from generating a rootfs. This is fixed by removing
the `-l`, as plainly invoking `mount -t devtmpfs` returns the same
output with `mount -l ...` on the non-busybox variant (on Arch Linux, it
comes from the `utils-linux` package). After this change, I was able to
run `./tools/testing/selftests/bpf/vmtest.sh -i` (from the kernel src;
with modification to the script to pick up my locally-generated .zstd of
the new rootfs) and it worked.

Signed-off-by: Chris Tarazi <tarazichris@gmail.com>
