### PR TITLE
ci: allow using s390x-self-hosted-builder on an Ubuntu host

### DIFF
--- a/travis-ci/rootfs/s390x-self-hosted-builder/README.md
+++ b/travis-ci/rootfs/s390x-self-hosted-builder/README.md
@@ -10,7 +10,8 @@ the master branch.
 ### Install prerequisites.
 
 ```
-$ sudo dnf install docker
+$ sudo dnf install docker        # RHEL
+$ sudo apt install -y docker.io  # Ubuntu
 ```
 
 ### Add services.
@@ -53,14 +54,15 @@ get the latest OS security fixes, use the following commands:
 $ sudo docker build \
       --pull \
       -f actions-runner-libbpf.Dockerfile \
-      -t iiilinuxibmcom/actions-runner-libbpf
+      -t iiilinuxibmcom/actions-runner-libbpf \
+      .
 $ sudo systemctl restart actions-runner-libbpf
 ```
 
 ## Removing persistent data
 
 The `actions-runner-libbpf` service stores various temporary data, such as
-runner  registration information, work directories and logs, in the
+runner registration information, work directories and logs, in the
 `actions-runner-libbpf` volume. In order to remove it and start from scratch,
 e.g. when upgrading the runner or switching it to a different repository, use
 the following commands:

--- a/travis-ci/rootfs/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
+++ b/travis-ci/rootfs/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
@@ -37,6 +37,7 @@ ARG version=2.285.0
 RUN useradd -m actions-runner
 RUN echo "actions-runner ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 RUN echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >>/etc/sudoers
+RUN usermod -a -G kvm actions-runner
 USER actions-runner
 ENV USER=actions-runner
 WORKDIR /home/actions-runner


### PR DESCRIPTION
This PR contains a small tweak for using s390x-self-hosted-builder on an Ubuntu host, as well as documentation changes.

In order to test this change, I've disabled the old RHEL-based builder and enabled the new Ubuntu one. If all tests pass, I'll keep it this way.