### PR TITLE
LICENSE: fix BSD-2-Clause by adding year and authors

### DIFF
--- a/LICENSE.BSD-2-Clause
+++ b/LICENSE.BSD-2-Clause
@@ -7,7 +7,7 @@ Usage-Guide:
     SPDX-License-Identifier: BSD-2-Clause
 License-Text:
 
-Copyright (c) <year> <owner> . All rights reserved.
+Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Seems like 2015 is the year of the first libbpf commit. So use Lorenz's
suggestion and add "(c) 2015 The Libbpf Authors".

Closes: https://github.com/libbpf/libbpf/issues/461
Reported-by: Lorenz Bauer <lmb@cloudflare.com>
Signed-off-by: Andrii Nakryiko <andrii@kernel.org>