### PR TITLE
libbpf: ensure F_DUPFD_CLOEXEC is defined

### DIFF
--- a/src/libbpf_internal.h
+++ b/src/libbpf_internal.h
@@ -31,6 +31,10 @@
 #define EM_BPF 247
 #endif
 
+#ifndef F_DUPFD_CLOEXEC
+#define F_DUPFD_CLOEXEC 1030
+#endif
+
 #ifndef R_BPF_64_64
 #define R_BPF_64_64 1
 #endif


### PR DESCRIPTION
This definition seems to be missing from some older toolchains.

Fixes:
```c
libbpf_internal.h:521:18: error: 'F_DUPFD_CLOEXEC' undeclared (first use in this function); did you mean 'FD_CLOEXEC'?
   fd = fcntl(fd, F_DUPFD_CLOEXEC, 3);
                  ^~~~~~~~~~~~~~~
                  FD_CLOEXEC
```

Alternative to #463.