### PR TITLE
[BUG] fix tc flag

### DIFF
--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -8647,7 +8647,7 @@ static const struct bpf_sec_def section_defs[] = {
 	SEC_DEF("uretprobe/",		KPROBE, 0, SEC_NONE),
 	SEC_DEF("kprobe.multi/",	KPROBE,	BPF_TRACE_KPROBE_MULTI, SEC_NONE, attach_kprobe_multi),
 	SEC_DEF("kretprobe.multi/",	KPROBE,	BPF_TRACE_KPROBE_MULTI, SEC_NONE, attach_kprobe_multi),
-	SEC_DEF("tc",			SCHED_CLS, 0, SEC_NONE),
+	SEC_DEF("tc",			SCHED_CLS, 0, SEC_NONE | SEC_SLOPPY_PFX),
 	SEC_DEF("classifier",		SCHED_CLS, 0, SEC_NONE | SEC_SLOPPY_PFX | SEC_DEPRECATED),
 	SEC_DEF("action",		SCHED_ACT, 0, SEC_NONE | SEC_SLOPPY_PFX),
 	SEC_DEF("tracepoint/",		TRACEPOINT, 0, SEC_NONE, attach_tp),


### PR DESCRIPTION
I encountered a problem when using tail call in TC, my main program and tail call BPF program are named like "tc/prog_a" and "tc/prog_b", but encountered such a problem "missing BPF prog type, check ELF section name", after checking the code I found that the problem lies in "sec_def_matches", for such a name of "tc/prog_b" will not match any rules in "sec_def_matches", it will cause "find_sec_def" to fail and cause prog ->type assignment failed.

Also "classifier" is currently declared as "SEC_DEPRECATED", which contains "SEC_SLOPPY_PFX", and the bpf_prog_type of "classifier" and "tc" are both SCHED_CLS, I think such vague prefix matching requirements are reasonable, so I think it may be is a bug. And when I add "SEC_SLOPPY_PFX" to "tc" my program can execute normally.