### PR TITLE
Makefile: Add usdt.bpf.h to list of HEADERS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,8 @@ endif
 
 HEADERS := bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h xsk.h \
 	   bpf_helpers.h bpf_helper_defs.h bpf_tracing.h \
-	   bpf_endian.h bpf_core_read.h skel_internal.h libbpf_version.h
+	   bpf_endian.h bpf_core_read.h skel_internal.h libbpf_version.h \
+	   usdt.bpf.h
 UAPI_HEADERS := $(addprefix $(TOPDIR)/include/uapi/linux/,\
 			    bpf.h bpf_common.h btf.h)
 


### PR DESCRIPTION
Add usdt.bpf.h to HEADERS so that it can be installed
and included by users.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>