### PR TITLE
ci: assorted tweaks related to libelf and OSS-Fuzz/CFLite mostly

### DIFF
--- a/scripts/build-fuzzers.sh
+++ b/scripts/build-fuzzers.sh
@@ -36,6 +36,11 @@ find -name Makefile.am | xargs sed -i 's/,--no-undefined//'
 # https://clang.llvm.org/docs/AddressSanitizer.html#usage
 sed -i 's/^\(ZDEFS_LDFLAGS=\).*/\1/' configure.ac
 
+if [[ "$SANITIZER" == undefined ]]; then
+    # That's basicaly what --enable-sanitize-undefined does to turn off unaligned access
+    # elfutils heavily relies on on i386/x86_64 but without changing compiler flags along the way
+    sed -i 's/\(check_undefined_val\)=[0-9]/\1=1/' configure.ac
+fi
 
 autoreconf -i -f
 if ! ./configure --enable-maintainer-mode --disable-debuginfod --disable-libdebuginfod \

--- a/scripts/build-fuzzers.sh
+++ b/scripts/build-fuzzers.sh
@@ -26,7 +26,7 @@ rm -rf elfutils
 git clone git://sourceware.org/git/elfutils.git
 (
 cd elfutils
-git checkout 983e86fd89e8bf02f2d27ba5dce5bf078af4ceda
+git checkout 83251d4091241acddbdcf16f814e3bc6ef3df49a
 git log --oneline -1
 
 # ASan isn't compatible with -Wl,--no-undefined: https://github.com/google/sanitizers/issues/380

--- a/scripts/build-fuzzers.sh
+++ b/scripts/build-fuzzers.sh
@@ -17,6 +17,14 @@ mkdir -p "$OUT"
 
 export LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE:--fsanitize=fuzzer}
 
+# libelf is compiled with _FORTIFY_SOURCE by default and it
+# isn't compatible with MSan. It was borrowed
+# from https://github.com/google/oss-fuzz/pull/7422
+if [[ "$SANITIZER" == memory ]]; then
+    CFLAGS+=" -U_FORTIFY_SOURCE"
+    CXXFLAGS+=" -U_FORTIFY_SOURCE"
+fi
+
 # The alignment check is turned off by default on OSS-Fuzz/CFLite so it should be
 # turned on explicitly there. It was borrowed from
 # https://github.com/google/oss-fuzz/pull/7092

--- a/scripts/build-fuzzers.sh
+++ b/scripts/build-fuzzers.sh
@@ -17,6 +17,16 @@ mkdir -p "$OUT"
 
 export LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE:--fsanitize=fuzzer}
 
+# The alignment check is turned off by default on OSS-Fuzz/CFLite so it should be
+# turned on explicitly there. It was borrowed from
+# https://github.com/google/oss-fuzz/pull/7092
+if [[ "$SANITIZER" == undefined ]]; then
+    additional_ubsan_checks=alignment
+    UBSAN_FLAGS="-fsanitize=$additional_ubsan_checks -fno-sanitize-recover=$additional_ubsan_checks"
+    CFLAGS+=" $UBSAN_FLAGS"
+    CXXFLAGS+=" $UBSAN_FLAGS"
+fi
+
 # Ideally libbelf should be built using release tarballs available
 # at https://sourceware.org/elfutils/ftp/. Unfortunately sometimes they
 # fail to compile (for example, elfutils-0.185 fails to compile with LDFLAGS enabled


### PR DESCRIPTION
* ci: turn off _FORTIFY_SOURCE explicitly

    libelf is compiled with _FORTIFY_SOURCE by default and it isn't compatible with MSan. It was borrowed from https://github.com/google/oss-fuzz/pull/7422

* ci: turn on the alignment check

    to catch issues like https://github.com/libbpf/libbpf/issues/391

* ci: point elfutils to a commit where a couple bugs are fixed

     Fixes
    ```
    ./out/bpf-object-fuzzer: Running 1 inputs 1 time(s) each.
    Running: CORPUS/036ff286c13e4590646c7ef59435ec642432da8e
    elf_begin.c:232:20: runtime error: member access within misaligned address 0x000001655e71 for type 'Elf64_Shdr', which requires 8 byte alignment
    0x000001655e71: note: pointer points here
     00 00 00  7f 45 4c 46 02 02 01 00  00 00 07 fb 00 1d 00 00  6c 69 63 65 42 fb 00 41  00 57 03 00 20
                  ^
        #0 0x574d51 in get_shnum /home/libbpf/elfutils/libelf/elf_begin.c:232:20
        #1 0x574d51 in file_read_elf /home/libbpf/elfutils/libelf/elf_begin.c:296:19
        #2 0x569c2c in __libelf_read_mmaped_file /home/libbpf/elfutils/libelf/elf_begin.c:559:14
        #3 0x58e812 in elf_memory /home/libbpf/elfutils/libelf/elf_memory.c:49:10
        #4 0x4905b4 in bpf_object__elf_init /home/libbpf/src/libbpf.c:1255:9
        #5 0x4905b4 in bpf_object_open /home/libbpf/src/libbpf.c:7104:8
        #6 0x49144e in bpf_object__open_mem /home/libbpf/src/libbpf.c:7171:20
        #7 0x483018 in LLVMFuzzerTestOneInput /home/libbpf/fuzz/bpf-object-fuzzer.c:16:8
        #8 0x439389 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/libbpf/out/bpf-object-fuzzer+0x439389)
        #9 0x419e2f in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/libbpf/out/bpf-object-fuzzer+0x419e2f)
        #10 0x421aee in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/libbpf/out/bpf-object-fuzzer+0x421aee)
        #11 0x410f96 in main (/home/libbpf/out/bpf-object-fuzzer+0x410f96)
        #12 0x7f153e21255f in __libc_start_call_main (/lib64/libc.so.6+0x2d55f)
        #13 0x7f153e21260b in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2d60b)
        #14 0x410fe4 in _start (/home/libbpf/out/bpf-object-fuzzer+0x410fe4)

    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior elf_begin.c:232:20 in
    ```
    and
    ```
    ./out/bpf-object-fuzzer: Running 1 inputs 1 time(s) each.
    Running: CORPUS/446b578d82c47fe177de6fd675f4cb6bae8d1ea9
    elf_begin.c:485:40: runtime error: addition of unsigned offset to 0x000002277e70 overflowed to 0x0000021d7e6f
        #0 0x5748f1 in file_read_elf /home/libbpf/elfutils/libelf/elf_begin.c:485:40
        #1 0x569c2c in __libelf_read_mmaped_file /home/libbpf/elfutils/libelf/elf_begin.c:559:14
        #2 0x58e812 in elf_memory /home/libbpf/elfutils/libelf/elf_memory.c:49:10
        #3 0x4905b4 in bpf_object__elf_init /home/libbpf/src/libbpf.c:1255:9
        #4 0x4905b4 in bpf_object_open /home/libbpf/src/libbpf.c:7104:8
        #5 0x49144e in bpf_object__open_mem /home/libbpf/src/libbpf.c:7171:20
        #6 0x483018 in LLVMFuzzerTestOneInput /home/libbpf/fuzz/bpf-object-fuzzer.c:16:8
        #7 0x439389 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/libbpf/out/bpf-object-fuzzer+0x439389)
        #8 0x419e2f in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/libbpf/out/bpf-object-fuzzer+0x419e2f)
        #9 0x421aee in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/libbpf/out/bpf-object-fuzzer+0x421aee)
        #10 0x410f96 in main (/home/libbpf/out/bpf-object-fuzzer+0x410f96)
        #11 0x7f753e38255f in __libc_start_call_main (/lib64/libc.so.6+0x2d55f)
        #12 0x7f753e38260b in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2d60b)
        #13 0x410fe4 in _start (/home/libbpf/out/bpf-object-fuzzer+0x410fe4)

    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior elf_begin.c:485:40 in
    ```

To make it easier to keep track of bugs found by OSS-Fuzz I opened https://github.com/google/oss-fuzz/pull/7549