### PR TITLE
Enable downloads feature

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ sphinx:
   builder: html
   configuration: docs/conf.py
 
+formats:
+  - all
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
    version: 3.7


### PR DESCRIPTION
This enables readthedocs to create downloadable files of every documentation version on build. This includes zipped HTML, PDF, and ePUB formats.

After this is merged I will rebuild every version manually. 

https://readthedocs.org/projects/docs/downloads/pdf/stable/

Signed-off-by: grantseltzer <grantseltzer@gmail.com>