### PR TITLE
Fix downloads formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,9 @@ sphinx:
   configuration: docs/conf.py
 
 formats:
-  - all
+  - htmlzip
+  - pdf
+  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Turns out I read the wrong documentation when I specified 'all' as the format. I also could have tested it on libbpf-test.readthedocs.org, which I did this time around. 

The issue however is that API docs aren't included in this, and i'm not  sure why. I'll look to address that soon.

https://readthedocs.org/projects/libbpf-test/downloads/
(when this is merged, i'll rebuild for every version)

Signed-off-by: grantseltzer <grantseltzer@gmail.com>