### PR TITLE
[rootfs] update rootfs to ship with ethtool

### DIFF
--- a/travis-ci/rootfs/mkrootfs_arch.sh
+++ b/travis-ci/rootfs/mkrootfs_arch.sh
@@ -80,6 +80,7 @@ packages=(
 	# selftests test_progs dependencies.
 	binutils
 	elfutils
+	ethtool
 	glibc
 	iproute2
 	# selftests test_verifier dependencies.

--- a/travis-ci/rootfs/mkrootfs_debian.sh
+++ b/travis-ci/rootfs/mkrootfs_debian.sh
@@ -15,7 +15,7 @@ root=$(mktemp -d -p "$PWD")
 trap 'rm -r "$root"' EXIT
 
 # Install packages.
-packages=binutils,busybox,elfutils,iproute2,libcap2,libelf1,strace,zlib1g
+packages=binutils,busybox,elfutils,ethtool,iproute2,libcap2,libelf1,strace,zlib1g
 debootstrap --include="$packages" --variant=minbase bullseye "$root"
 
 # Remove the init scripts (tests use their own). Also remove various


### PR DESCRIPTION
Add `ethtool` as a dependency to the rootfs image.

Tested by running and building the rootfs images with both
`sudo ./mkrootfs_arch.sh`
and
`sudo ./mkrootfs_debian.sh`

and running in qemu with:
```
wget https://libbpf-ci.s3-us-west-1.amazonaws.com/x86_64/vmlinuz-5.5.0
rootfs_img=rootfs.img kernel_bzimage=vmlinuz-5.5.0

mkdir rootfs
touch rootfs.img
truncate -s 2G rootfs.img
sudo mount -o loop rootfs.img rootfs
cat ~/Downloads/libbpf-vmtest-rootfs-2022.04.25.tar.zst | sudo tar -C rootfs -I zstd -xvf -
sudo install  -m 755 -o root -g root  /dev/stdin rootfs/etc/rcS.d/S50-startup <<'EOF'
ethtool -h
cat /etc/issue
EOF

qemu-system-x86_64 -nodefaults  -display none -serial mon:stdio -enable-kvm -m 4G -drive file="${rootfs_img}",format=raw,index=1,media=disk,if=virtio,cache=none -kernel "${kernel_bzimage}" -append "root=/dev/vda rw console=ttyS0,115200"
```

The last block printed ethtool's help, confirming the presence of
ethtool in the rootfs.

`libbpf-vmtest-rootfs-2022.04.25.tar.zst` was generated and uploaded to S3. INDEX in libbpf/ci needs to be changed to make the CI pick it up.