### PR TITLE
Fix bpf_prog_load() pointing error causing libbcc segfault

### DIFF
--- a/src/libbpf.map
+++ b/src/libbpf.map
@@ -61,7 +61,6 @@ LIBBPF_0.0.1 {
 		bpf_prog_detach2;
 		bpf_prog_get_fd_by_id;
 		bpf_prog_get_next_id;
-		bpf_prog_load;
 		bpf_prog_load_xattr;
 		bpf_prog_query;
 		bpf_prog_test_run;


### PR DESCRIPTION
# ENV

* CentOS Stream9
* gcc (GCC) 11.3.1 20220421 (Red Hat 11.3.1-2)
* LLVM version 14.0.0

# bpftrace SEGV fault

```
(gdb) bt
#0  0x00007ffff00eee7d in __strlen_avx2 () from /lib64/libc.so.6
#1  0x00007ffff0095278 in __vfprintf_internal () from /lib64/libc.so.6
#2  0x00007ffff0095a3f in buffered_vfprintf () from /lib64/libc.so.6
#3  0x00007ffff7f68c10 in libbpf_print (level=level@entry=LIBBPF_DEBUG, format=format@entry=0x7ffff7f9452e "libbpf: loading %s\n") at libbpf.c:103
#4  0x00007ffff7f75e82 in __bpf_object__open_xattr (attr=attr@entry=0x7fffffffaf40, flags=0) at libbpf.c:7435
#5  0x00007ffff7f7d917 in bpf_prog_load_xattr2 (attr=attr@entry=0x7fffffffaf90, pobj=0x5555557a310b, prog_fd=0x7fffffffc590) at libbpf.c:10093
#6  0x00007ffff7f7dad3 in bpf_prog_load_deprecated (file=<optimized out>, type=<optimized out>, pobj=<optimized out>, prog_fd=<optimized out>) at libbpf.c:10158
#7  0x00007ffff1025c78 in libbpf_bpf_prog_load (load_attr=0x7fffffffb210, log_buf=0x0, log_buf_sz=0) at /home/rongtao/Git/bcc/src/cc/libbpf.c:672
#8  0x00007ffff10260af in bcc_prog_load_xattr (attr=0x7fffffffb210, prog_len=16, log_buf=0x7fffffffb540 "", log_buf_size=4096, allow_rlimit=true)
    at /home/rongtao/Git/bcc/src/cc/libbpf.c:758
#9  0x00007ffff10264c7 in bcc_prog_load (prog_type=BPF_PROG_TYPE_TRACING, name=0x5555557a30a9 "kfunc__sched_fork", insns=0x7fffffffc590, prog_len=16, license=0x5555557a310b "GPL",
    kern_version=331533, log_level=0, log_buf=0x7fffffffb540 "", log_buf_size=4096) at /home/rongtao/Git/bcc/src/cc/libbpf.c:880
#10 0x00005555556cd65c in bpftrace::try_load(char const*, libbpf::bpf_prog_type, bpf_insn*, unsigned long, int, char*, unsigned long) [clone .constprop.0] (
    name=name@entry=0x5555557a30a9 "kfunc__sched_fork", prog_type=prog_type@entry=libbpf::BPF_PROG_TYPE_TRACING, insns=insns@entry=0x7fffffffc590, insns_cnt=insns_cnt@entry=2,
    loglevel=loglevel@entry=0, logbuf=logbuf@entry=0x7fffffffb540 "", logbuf_size=4096) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/bpffeature.cpp:45
#11 0x0000555555621341 in bpftrace::try_load (prog_type=<optimized out>, insns=0x7fffffffc590, len=2, name=<optimized out>)
    at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/bpffeature.cpp:87
#12 0x0000555555621505 in bpftrace::BPFfeature::detect_prog_type (this=0x555555a17a10, name=0x0, prog_type=libbpf::BPF_PROG_TYPE_TRACING)
    at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/bpffeature.cpp:141
#13 bpftrace::BPFfeature::has_prog_kfunc (this=0x555555a17a10) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/bpffeature.h:102
#14 0x00005555556ad121 in bpftrace::ast::SemanticAnalyser::visit (this=0x7fffffffdd50, ap=...) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/ast/semantic_analyser.cpp:2552
#15 0x00005555556a8ee3 in bpftrace::ast::AttachPoint::accept (v=..., this=0x555555a20f90) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/ast/ast.cpp:36
#16 bpftrace::ast::SemanticAnalyser::visit (this=0x7fffffffdd50, probe=...) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/ast/semantic_analyser.cpp:2625
#17 0x00005555556a4144 in bpftrace::ast::Probe::accept (v=..., this=<optimized out>) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/ast/ast.cpp:41
#18 bpftrace::ast::SemanticAnalyser::visit (this=0x7fffffffdd50, program=...) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/ast/semantic_analyser.cpp:2642
#19 0x00005555556a427b in bpftrace::ast::SemanticAnalyser::analyse (this=0x7fffffffdd50) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/ast/semantic_analyser.cpp:2653
#20 0x00005555555e40d6 in main (argc=2, argv=0x7fffffffe678) at /usr/src/debug/bpftrace-0.12.1-8.el9.x86_64/src/main.cpp:532
```

In 'libbpf_bpf_prog_load()' call 'bpf_prog_load()' with 6 args,  shouldn't call 'bpf_prog_load_deprecated()' with 4 args. but was  called.

See also https://github.com/iovisor/bcc/pull/4021