### PR TITLE
Preserve errno when calling libbpf_print().

### DIFF
--- a/src/libbpf_internal.h
+++ b/src/libbpf_internal.h
@@ -148,7 +148,9 @@ extern void libbpf_print(enum libbpf_print_level level,
 
 #define __pr(level, fmt, ...)	\
 do {				\
+	int __saved_errno = errno;							\
 	libbpf_print(level, "libbpf: " fmt, ##__VA_ARGS__);	\
+	errno = __saved_errno;								\
 } while (0)
 
 #define pr_warn(fmt, ...)	__pr(LIBBPF_WARN, fmt, ##__VA_ARGS__)


### PR DESCRIPTION
pr_*() functions may be called from a context that errno need to be
preserved.

For example, In perf_event_open_probe(), pr_warn() is called before
return an error. And at caller side, bpf_program__attach_kprobe_opts()
check the errno value to report an error.

if pr_warn() clear the errno, some strange issue will happen like
follow:

Attaching 1 Kprobes.
WARN  : libbpf: kprobe perf_event_open() failed: Invalid argument
WARN  : libbpf: prog 'stacktrace_kb': failed to create kprobe 'vfs_caches_init+0x0' perf event: Success

First WARN is from perf_event_open_probe(), error is "Invalid argument"
and the second WARN is from bpf_program__attach_kprobe_opts() which
faied to recognaize the error and report as success.

Because the log function libbpf_print() used in  pr_*() is in fact a
callback function from the user, there is no guarantee for errno to be
preserved in it.

This commit saved and restored errno when calling libbpf_print().

Signed-off-by: Seimizu Joukan <joukan.seimizu@gmail.com>