### PR TITLE
Rely on upstream kernel configuration

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -43,7 +43,10 @@ runs:
       run: |
         echo "::group::Prepare buidling selftest"
         cd .kernel
-        cp ${{ github.workspace }}/travis-ci/vmtest/configs/config-latest.${{ inputs.arch }} .config
+        cat tools/testing/selftests/bpf/config \
+            tools/testing/selftests/bpf/config.${{ inputs.arch }} \
+            ${{ github.workspace }}/travis-ci/vmtest/configs/config-latest \
+            ${{ github.workspace }}/travis-ci/vmtest/configs/config-latest.${{ inputs.arch }} 2> /dev/null > .config && :
         make olddefconfig && make prepare
         cd -
         echo "::endgroup::"


### PR DESCRIPTION
So far we have relied on the kernel configuration as checked into the
this repository. However, a suitable configuration is now included in
upstream Linux [0].
With this change we add support for using the configuration from there.

[0] https://lore.kernel.org/bpf/165893461358.29339.11641967418379627671.git-patchwork-notify@kernel.org/T/#m2a97b0ea9ef0ddee7a53bbf7919e3f324b233937

Signed-off-by: Daniel Müller <deso@posteo.net>