### PR TITLE
ci: Bump LLVM version we use to 16

### DIFF
--- a/.github/actions/build-selftests/build_selftests.sh
+++ b/.github/actions/build-selftests/build_selftests.sh
@@ -8,7 +8,7 @@ source ${THISDIR}/helpers.sh
 
 foldable start prepare_selftests "Building selftests"
 
-LLVM_VER=15
+LLVM_VER=16
 LIBBPF_PATH="${REPO_ROOT}"
 
 PREPARE_SELFTESTS_SCRIPT=${THISDIR}/prepare_selftests-${KERNEL}.sh


### PR DESCRIPTION
Development on LLVM 16 has started and version 15 is no longer available
in the repository we install it from. Bump the version we use
accordingly.

Signed-off-by: Daniel Müller <deso@posteo.net>