### PR TITLE
Use checkout action in version v3

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # setup envinronment
+    # setup environment
     - name: Setup environment
       uses: libbpf/ci/setup-build-env@master
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           - name: gcc-10 ASan+UBSan
             target: RUN_GCC10_ASAN
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
       - uses: ./.github/actions/setup
         name: Setup
@@ -53,7 +53,7 @@ jobs:
           - arch: s390x
           - arch: x86
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
       - uses: ./.github/actions/setup
         name: Pre-Setup

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'libbpf/libbpf'
     name: Coverity
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: Run coverity
         run: |

--- a/.github/workflows/ondemand.yml
+++ b/.github/workflows/ondemand.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     name: vmtest with customized pahole/Kernel
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/vmtest
         with:

--- a/.github/workflows/pahole.yml
+++ b/.github/workflows/pahole.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       STAGING: tmp.master
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/vmtest
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
             runs_on: z15
             arch: 's390x'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
       - uses: ./.github/actions/setup
         name: Setup


### PR DESCRIPTION
The current version of actions/checkout is v3. That means that v2, which
we currently use, has been superseded. Update the version we use
accordingly.

Signed-off-by: Daniel Müller <deso@posteo.net>