### PR TITLE
Re-enable test_maps selftest

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -58,6 +58,6 @@ cd ${PROJECT_NAME}/selftests/bpf
 test_progs
 
 if [[ "${KERNEL}" == 'latest' ]]; then
-	# test_maps
+	test_maps
 	test_verifier
 fi


### PR DESCRIPTION
Back in 2020, we disabled the test_maps selftest with e05f9be4f4be
("vmtests: temporarily disable test_maps"), for reasons not closely
elaborated.
It appears that by now the test is succeeding again, so let's enable it
back.

Signed-off-by: Daniel Müller <deso@posteo.net>