### PR TITLE
Explicitly specify Qemu image path to use

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -79,6 +79,7 @@ runs:
         kernel: ${{ inputs.kernel }}
         project-name: 'libbpf'
         arch: ${{ inputs.arch }}
+        image-output: '/tmp/root.img'
     # 5. run selftest in QEMU
     - name: Run selftests
       uses: libbpf/ci/run-qemu@master


### PR DESCRIPTION
The path to the file system image used by our invocation of Qemu is
currently hard coded to `/tmp/root.img`. With
https://github.com/libbpf/ci/commit/da44c0b6ee29ec53776c1303f7ac790b7e337db5
landed we have the option of specifying it explicitly. Let's do just that.

Signed-off-by: Daniel Müller <deso@posteo.net>