### PR TITLE
readme: add inverted logo version for dark background

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-<img src="https://user-images.githubusercontent.com/508075/185997470-2f427d3d-f040-4eef-afc5-ae4f766615b2.png" width="40%" >
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/508075/185997470-2f427d3d-f040-4eef-afc5-ae4f766615b2.png" width="40%">
+  <img src="https://user-images.githubusercontent.com/17001771/186033544-26fae355-1daa-42fb-bb46-46bbaa01caab.png" width="40%">
+</picture>
 
 libbpf
 [![Github Actions Builds & Tests](https://github.com/libbpf/libbpf/actions/workflows/test.yml/badge.svg)](https://github.com/libbpf/libbpf/actions/workflows/test.yml)


### PR DESCRIPTION
The original version of the logo and the accompanying text are not really readable on a dark background. This PR is a proposal to use an inverted version of the logo in that case.

Preview available on [the README in my branch](https://github.com/qmonnet/libbpf/tree/pr/logo-inverted).

![image](https://user-images.githubusercontent.com/17001771/186036379-c573631d-fe53-447d-8c4e-444c2d704583.png)![image](https://user-images.githubusercontent.com/17001771/186036118-85751a02-5293-4b74-8a77-c6dfa0a8bc73.png)

The proposed alternate logo is white and transparent. We lose the yellow part on the wings. This is just a suggestion, given that I suppose you have your own preferences on the matter, so let me know (or feel free to edit the PR). Instead of an inverted logo, we could also use a white border, or a coloured (yellow?) background.