### PR TITLE
Use foldable helpers where applicable

### DIFF
--- a/.github/actions/build-selftests/action.yml
+++ b/.github/actions/build-selftests/action.yml
@@ -18,9 +18,10 @@ runs:
   steps:
     - shell: bash
       run: |
-        echo "::group::Setup Env"
+        source $GITHUB_ACTION_PATH/../../../ci/vmtest/helpers.sh
+        foldable start "Setup Env"
         sudo apt-get install -y qemu-kvm zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
-        echo "::endgroup::"
+        foldable end
     - shell: bash
       run: |
         export KERNEL=${{ inputs.kernel }}

--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -41,24 +41,26 @@ runs:
     - name: Prepare to build BPF selftests
       shell: bash
       run: |
-        echo "::group::Prepare building selftest"
+        source $GITHUB_ACTION_PATH/../../../ci/vmtest/helpers.sh
+        foldable start "Prepare building selftest"
         cd .kernel
         cat tools/testing/selftests/bpf/config \
             tools/testing/selftests/bpf/config.${{ inputs.arch }} > .config
         make olddefconfig && make prepare
         cd -
-        echo "::endgroup::"
+        foldable end
     # 2. if kernel == LATEST, build kernel image from tree
     - name: Build kernel image
       if: ${{ inputs.kernel == 'LATEST' }}
       shell: bash
       run: |
-        echo "::group::Build Kernel Image"
+        source $GITHUB_ACTION_PATH/../../../ci/vmtest/helpers.sh
+        foldable start "Build Kernel Image"
         cd .kernel
         make -j $((4*$(nproc))) all > /dev/null
         cp vmlinux ${{ github.workspace }}
         cd -
-        echo "::endgroup::"
+        foldable end
     # else, just download prebuilt kernel image
     - name: Download prebuilt kernel
       if: ${{ inputs.kernel != 'LATEST' }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -15,12 +15,13 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Run coverity
         run: |
-          echo ::group::Setup CI env
+          source $GITHUB_ACTION_PATH/../../../ci/vmtest/helpers.sh
+          foldable start "Setup CI env"
           source /tmp/ci_setup
           export COVERITY_SCAN_NOTIFICATION_EMAIL="${AUTHOR_EMAIL}"
           export COVERITY_SCAN_BRANCH_PATTERN=${GITHUB_REF##refs/*/}
           export TRAVIS_BRANCH=${COVERITY_SCAN_BRANCH_PATTERN}
-          echo ::endgroup::
+          foldable end
           scripts/coverity.sh
         env:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
As discussed at some earlier point in time, some of the actions/workflow
logic does not use our foldable helpers despite being able to. Switch
them over.

Signed-off-by: Daniel Müller <deso@posteo.net>