### PR TITLE
[s390x] support for consistent runner name + action runner update

### DIFF
--- a/ci/rootfs/s390x-self-hosted-builder/README.md
+++ b/ci/rootfs/s390x-self-hosted-builder/README.md
@@ -36,6 +36,7 @@ $ sudo systemctl daemon-reload
 $ sudo tee /etc/actions-runner-libbpf
 repo=<owner>/<name>
 access_token=<ghp_***>
+runner_name=<hostname>
 ```
 
 Access token should have the repo scope, consult

--- a/ci/rootfs/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
+++ b/ci/rootfs/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
@@ -33,7 +33,7 @@ RUN ln -fs /etc/resolv.conf /usr/x86_64-linux-gnu/etc/
 ENV QEMU_LD_PREFIX=/usr/x86_64-linux-gnu
 
 # amd64 Github Actions Runner.
-ARG version=2.285.0
+ARG version=2.296.0
 RUN useradd -m actions-runner
 RUN echo "actions-runner ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 RUN echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >>/etc/sudoers

--- a/ci/rootfs/s390x-self-hosted-builder/fs/usr/bin/actions-runner
+++ b/ci/rootfs/s390x-self-hosted-builder/fs/usr/bin/actions-runner
@@ -7,7 +7,7 @@
 #
 # - repo=<owner>/<name>
 # - access_token=<ghp_***>
-#
+# - runner_name=<hostname>
 
 set -e -u
 
@@ -34,6 +34,7 @@ registration_token=$(jq --raw-output .token "$token_file")
     --url "https://github.com/$repo" \
     --token "$registration_token" \
     --labels z15 \
+    --name "$runner_name" \
     --ephemeral
 
 # Run one job.


### PR DESCRIPTION
* use hostname to set the runner name
* updated https://github.com/actions/runner from c2.285.0 to v2.296.0