### PR TITLE
Explicitly provide kernel-root argument to `prepare-rootfs` action

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -78,9 +78,10 @@ runs:
     - name: prepare rootfs
       uses: libbpf/ci/prepare-rootfs@master
       with:
-        kernel: ${{ inputs.kernel }}
         project-name: 'libbpf'
         arch: ${{ inputs.arch }}
+        kernel: ${{ inputs.kernel }}
+        kernel-root: '.kernel'
         image-output: '/tmp/root.img'
     # 5. run selftest in QEMU
     - name: Run selftests


### PR DESCRIPTION
Let's make the "kernel-root" explicit when using the `prepare-rootfs`
action, instead of relying on the default, `.kernel`.

Signed-off-by: Daniel Müller <deso@posteo.net>