### PR TITLE
Provide kernel-root argument to run-qemu action

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -87,6 +87,7 @@ runs:
     - name: Run selftests
       uses: libbpf/ci/run-qemu@master
       with:
+        arch: ${{ inputs.arch }}
         img: '/tmp/root.img'
         vmlinuz: 'vmlinuz'
-        arch: ${{ inputs.arch }}
+        kernel-root: '.kernel'


### PR DESCRIPTION
With https://github.com/libbpf/ci/pull/36 merged the run-qemu action now
accepts an additional argument, `kernel-root`.
Provide it to the action with the value appropriate for this repository.

Signed-off-by: Daniel Müller <deso@posteo.net>