### PR TITLE
Set KERNEL and REPO_ROOT environment variable for run-qemu action

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -85,6 +85,9 @@ runs:
         image-output: '/tmp/root.img'
     # 5. run selftest in QEMU
     - name: Run selftests
+      env:
+        KERNEL: ${{ inputs.kernel }}
+        REPO_ROOT: ${{ github.workspace }}
       uses: libbpf/ci/run-qemu@master
       with:
         img: '/tmp/root.img'


### PR DESCRIPTION
With an upcoming change we would like to invoke bpftool checks from the
run-qemu action (https://github.com/libbpf/ci/pull/37). This action
requires two environment variables, `KERNEL` and `REPO_ROOT`, set in order
to function.
Make sure to set them now. Long term we should probably make them
explicit input arguments instead of implicit global state, but there are
many more such instances that we need to clean up.

Signed-off-by: Daniel Müller <deso@posteo.net>