### PR TITLE
Other dynamic library link to libbpf.a will meet errors(https://githu…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,6 +32,7 @@ TOPDIR = ..
 INCLUDES := -I. -I$(TOPDIR)/include -I$(TOPDIR)/include/uapi
 ALL_CFLAGS := $(INCLUDES)
 
+STATIC_CFLAGS += -fPIC -shared
 SHARED_CFLAGS += -fPIC -fvisibility=hidden -DSHARED
 
 CFLAGS ?= -g -O2 -Werror -Wall -std=gnu89
@@ -127,7 +128,7 @@ $(STATIC_OBJDIR) $(SHARED_OBJDIR):
 
 $(STATIC_OBJDIR)/%.o: %.c | $(STATIC_OBJDIR)
 	$(call msg,CC,$@)
-	$(Q)$(CC) $(ALL_CFLAGS) $(CPPFLAGS) -c $< -o $@
+	$(Q)$(CC) $(ALL_CFLAGS) $(STATIC_CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 $(SHARED_OBJDIR)/%.o: %.c | $(SHARED_OBJDIR)
 	$(call msg,CC,$@)


### PR DESCRIPTION
Other dynamic library link to libbpf.a will meet errors(https://github.com/libbpf/libbpf/issues/577).
`-fPIC -shared` of CFLAG should be added when static library compiling.

Signed-off-by: Chen Yahui goodluckwillcomesoon@gmail.com