### PR TITLE
Fix comment: WHITELIST -> ALLOWLIST

### DIFF
--- a/ci/vmtest/configs/DENYLIST-5.5.0
+++ b/ci/vmtest/configs/DENYLIST-5.5.0
@@ -1,5 +1,5 @@
 # This file is not used and is there for historic purposes only.
-# See WHITELIST-5.5.0 instead.
+# See ALLOWLIST-5.5.0 instead.
 
 # PERMANENTLY DISABLED
 align			# verifier output format changed


### PR DESCRIPTION
Commit 693de729d0a2 ("Rename blacklists and whitelists") renamed the
black and white lists but missed the adjustment of a comment,
referencing a file name. Update it accordingly.

Signed-off-by: Daniel Müller <deso@posteo.net>