### PR TITLE
Adding network diag utils into actions-runner-libbpf container

### DIFF
--- a/ci/rootfs/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
+++ b/ci/rootfs/s390x-self-hosted-builder/actions-runner-libbpf.Dockerfile
@@ -24,7 +24,9 @@ RUN apt-get update && apt-get -y install \
         rsync \
         software-properties-common \
         sudo \
-        tree
+        tree \
+        iproute2 \
+        iputils-ping
 
 # amd64 dependencies.
 COPY --from=ld-prefix / /usr/x86_64-linux-gnu/


### PR DESCRIPTION
iproute2 and iputils-ping inside the container can be used to implement healthchecks or for troubleshooting.