### PR TITLE
[s390x][ci] Force replacing workers when a worker already exist with

### DIFF
--- a/ci/rootfs/s390x-self-hosted-builder/fs/usr/bin/actions-runner
+++ b/ci/rootfs/s390x-self-hosted-builder/fs/usr/bin/actions-runner
@@ -34,6 +34,8 @@ registration_token=$(jq --raw-output .token "$token_file")
     --url "https://github.com/$repo" \
     --token "$registration_token" \
     --labels z15 \
+    --replace \
+    --unattended \
     --name "$runner_name" \
     --ephemeral
 


### PR DESCRIPTION
same name.

This is essentially aligning whith what is done in https://github.com/myoung34/docker-github-actions-runner/blob/0f2883e196f6fc1d9b63ee4473d534e387801f0b/entrypoint.sh#L90-L91

The issue at hand did manifest on s390x host when restarting a runner and GH having an existing runner with the same name. The logic was to default to not replace it and the runner would be started with somne defaults, which mean the name would change, and the labels would be lost, making the runner unusable (while still running): https://gist.github.com/chantra/ef0bd3e0c9e35bb82619636acf2f7c98

By replacing the existing runner, we will not get into that state.