### PR TITLE
Add deny_namespace to DENYLIST-latest.s390x on CI

### DIFF
--- a/ci/vmtest/configs/DENYLIST-latest.s390x
+++ b/ci/vmtest/configs/DENYLIST-latest.s390x
@@ -1,4 +1,5 @@
 # TEMPORARY until bpf-next -> bpf merge
+deny_namespace                           # failed to attach: ERROR: strerror_r(-524)=22                                (trampoline)
 lru_bug                                  # prog 'printk': failed to auto-attach: -524
 
 # TEMPORARY


### PR DESCRIPTION
The deny_namespace selftest was recently added to validate the userns_create LSM hooks. The test does not work on s390x because LSM uses BPF trampoline.
8206e4e95230 ("selftests/bpf: Add selftest deny_namespace to s390x deny list") was added to the bpf-next tree, but the bpf CI runs are still failing because the commit is not in that tree. So as to avoid merge conflicts, let's just blacklist it on libbpf CI.

Signed-off-by: David Vernet <void@manifault.com>