### PR TITLE
Remove lru_bug from DENYLIST-latest.s390x

### DIFF
--- a/ci/vmtest/configs/DENYLIST-latest.s390x
+++ b/ci/vmtest/configs/DENYLIST-latest.s390x
@@ -1,6 +1,3 @@
-# TEMPORARY until bpf-next -> bpf merge
-lru_bug                                  # prog 'printk': failed to auto-attach: -524
-
 # TEMPORARY
 usdt/basic                               # failing verifier due to bounds check after LLVM update
 usdt/multispec                           # same as above


### PR DESCRIPTION
The comment associated with the entry is a bit confusing. It stemmed from the test being denylisted on `bpf`, but not `bpf-next` in the past. Regardless, by now said change has propagated to both trees, so we no longer need to carry around this deny list entry here.

Signed-off-by: Daniel Müller <deso@posteo.net>