### PR TITLE
Makefile: Fix cross-compilation for 32-bit targets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -77,7 +77,8 @@ INSTALL = install
 
 DESTDIR ?=
 
-ifeq ($(filter-out %64 %64be %64eb %64le %64el s390x, $(shell uname -m)),)
+HOSTARCH = $(firstword $(subst -, ,$(shell $(CC) -dumpmachine)))
+ifeq ($(filter-out %64 %64be %64eb %64le %64el s390x, $(HOSTARCH)),)
 	LIBSUBDIR := lib64
 else
 	LIBSUBDIR := lib


### PR DESCRIPTION
Determining the correct library installation path (lib vs. lib64) using uname(1) breaks in cross compilation scenarios where word widths differ between the host and target system.

Instead, source the information from the compilers '-dumpmachine' option (supported by both GCC and Clang).

We call this the "host" architecture, using the same nomenclature as Autotools (--host configure option).

Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>