### PR TITLE
ci: Provide KBUILD_OUTPUT to actions asking for it

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -77,11 +77,14 @@ runs:
     # 4. prepare rootfs
     - name: prepare rootfs
       uses: libbpf/ci/prepare-rootfs@master
+      env:
+        KBUILD_OUTPUT: '.kernel'
       with:
         project-name: 'libbpf'
         arch: ${{ inputs.arch }}
         kernel: ${{ inputs.kernel }}
         kernel-root: '.kernel'
+        kbuild-output: ${{ env.KBUILD_OUTPUT }}
         image-output: '/tmp/root.img'
     # 5. run selftest in QEMU
     - name: Run selftests


### PR DESCRIPTION
As of https://github.com/libbpf/ci/pull/67 a bunch of actions honor KBUILD_OUTPUT. Doing so will make it possible to separate source code from build artifacts, which in turn may allow us to support incremental kernel compilation in CI down the line.
Irrespective of these future changes, actions pertaining the kernel build now ask for an additional input defining where to store or expect build artifacts. Provide it.

Signed-off-by: Daniel Müller <deso@posteo.net>