### PR TITLE
ci: build libbpf with more versions of clang and gcc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,24 @@ jobs:
             target: RUN
           - name: ASan+UBSan
             target: RUN_ASAN
-          - name: clang
-            target: RUN_CLANG
           - name: clang ASan+UBSan
             target: RUN_CLANG_ASAN
-          - name: gcc-10
-            target: RUN_GCC10
           - name: gcc-10 ASan+UBSan
             target: RUN_GCC10_ASAN
+          - name: clang
+            target: RUN_CLANG
+          - name: clang-14
+            target: RUN_CLANG14
+          - name: clang-15
+            target: RUN_CLANG15
+          - name: clang-16
+            target: RUN_CLANG16
+          - name: gcc-10
+            target: RUN_GCC10
+          - name: gcc-11
+            target: RUN_GCC11
+          - name: gcc-12
+            target: RUN_GCC12
     steps:
       - uses: actions/checkout@v3
         name: Checkout

--- a/ci/managers/debian.sh
+++ b/ci/managers/debian.sh
@@ -6,7 +6,7 @@ CONT_NAME="${CONT_NAME:-libbpf-debian-$DEBIAN_RELEASE}"
 ENV_VARS="${ENV_VARS:-}"
 DOCKER_RUN="${DOCKER_RUN:-docker run}"
 REPO_ROOT="${REPO_ROOT:-$PWD}"
-ADDITIONAL_DEPS=(clang pkgconf gcc-10)
+ADDITIONAL_DEPS=(pkgconf)
 EXTRA_CFLAGS=""
 EXTRA_LDFLAGS=""
 
@@ -47,23 +47,31 @@ for phase in "${PHASES[@]}"; do
             docker_exec aptitude -y install "${ADDITIONAL_DEPS[@]}"
             echo -e "::endgroup::"
             ;;
-        RUN|RUN_CLANG|RUN_GCC10|RUN_ASAN|RUN_CLANG_ASAN|RUN_GCC10_ASAN)
+        RUN|RUN_CLANG|RUN_CLANG14|RUN_CLANG15|RUN_CLANG16|RUN_GCC10|RUN_GCC11|RUN_GCC12|RUN_ASAN|RUN_CLANG_ASAN|RUN_GCC10_ASAN)
             CC="cc"
-            if [[ "$phase" = *"CLANG"* ]]; then
+            if [[ "$phase" =~ "RUN_CLANG(\d+)(_ASAN)?" ]]; then
+                ENV_VARS="-e CC=clang-${BASH_REMATCH[1]} -e CXX=clang++-${BASH_REMATCH[1]}"
+                CC="clang-${BASH_REMATCH[1]}"
+            elif [[ "$phase" = *"CLANG"* ]]; then
                 ENV_VARS="-e CC=clang -e CXX=clang++"
                 CC="clang"
-            elif [[ "$phase" = *"GCC10"* ]]; then
-                ENV_VARS="-e CC=gcc-10 -e CXX=g++-10"
-                CC="gcc-10"
+            elif [[ "$phase" =~ "RUN_GCC(\d+)(_ASAN)?" ]]; then
+                ENV_VARS="-e CC=gcc-${BASH_REMATCH[1]} -e CXX=g++-${BASH_REMATCH[1]}"
+                CC="gcc-${BASH_REMATCH[1]}"
             fi
             if [[ "$phase" = *"ASAN"* ]]; then
                 EXTRA_CFLAGS="${EXTRA_CFLAGS} -fsanitize=address,undefined"
                 EXTRA_LDFLAGS="${EXTRA_LDFLAGS} -fsanitize=address,undefined"
             fi
+            if [[ "$CC" != "cc" ]]; then
+                docker_exec aptitude -y install "$CC"
+            else
+                docker_exec aptitude -y install gcc
+            fi
             docker_exec mkdir build install
             docker_exec ${CC} --version
             info "build"
-	    docker_exec make -j$((4*$(nproc))) EXTRA_CFLAGS="${EXTRA_CFLAGS}" EXTRA_LDFLAGS="${EXTRA_LDFLAGS}" -C ./src -B OBJDIR=../build
+            docker_exec make -j$((4*$(nproc))) EXTRA_CFLAGS="${EXTRA_CFLAGS}" EXTRA_LDFLAGS="${EXTRA_LDFLAGS}" -C ./src -B OBJDIR=../build
             info "ldd build/libbpf.so:"
             docker_exec ldd build/libbpf.so
             if ! docker_exec ldd build/libbpf.so | grep -q libelf; then


### PR DESCRIPTION
Add few more versions of clang and gcc used to compile-test libbpf.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>