### PR TITLE
ci: Use `s390x` label to schedule workflows on s390x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             runs_on: ubuntu-latest
             arch: 'x86_64'
           - kernel: 'LATEST'
-            runs_on: z15
+            runs_on: s390x
             arch: 's390x'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The runners are having their labels uniformized across architecture. z15 is being removed in favor of s390x.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>