### PR TITLE
ci: fix Ubuntu version for kernel tests and pahole workflows

### DIFF
--- a/.github/workflows/pahole.yml
+++ b/.github/workflows/pahole.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   vmtest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Kernel LATEST + staging pahole
     env:
       STAGING: tmp.master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
       matrix:
         include:
           - kernel: 'LATEST'
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-20.04
             arch: 'x86_64'
           - kernel: '5.5.0'
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-20.04
             arch: 'x86_64'
           - kernel: '4.9.0'
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-20.04
             arch: 'x86_64'
           - kernel: 'LATEST'
             runs_on: s390x


### PR DESCRIPTION
Having too new build environment in workflows that build selftests on the host, but run them in a separate QEMU image can lead to problems with runtime linker complaining about missing new enough version of glibc and other dependencies.

Until we update images, fix used Ubuntu version to ubuntu-20.04 to mitigate.

Suggested-by: Manu Bretelle <chantr4@gmail.com>
Signed-off-by: Andrii Nakryiko <andrii@kernel.org>