### PR TITLE
ci: list tests to run explicitly

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -94,6 +94,7 @@ runs:
       uses: libbpf/ci/run-qemu@master
       with:
         arch: ${{ inputs.arch }}
+        kernel-test: 'test_progs,test_progs_no_alu32,test_verifier'
         img: '/tmp/root.img'
         vmlinuz: 'vmlinuz'
         kernel-root: '.kernel'


### PR DESCRIPTION
Only allow test_progs, test_progs-no_alu32, and test_verifier. We don't like test_maps.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>