### PR TITLE
ci: Add patch setting CONFIG_FUNCTION_ERROR_INJECTION in CI

### DIFF
--- a/ci/diffs/0001-selftests-bpf-Select-CONFIG_FUNCTION_ERROR_INJECTION.patch
+++ b/ci/diffs/0001-selftests-bpf-Select-CONFIG_FUNCTION_ERROR_INJECTION.patch
@@ -1,0 +1,46 @@
+From a8dfde09c90109e3a98af54847e91bde7dc2d5c2 Mon Sep 17 00:00:00 2001
+From: Song Liu <song@kernel.org>
+Date: Tue, 13 Dec 2022 14:05:00 -0800
+Subject: [PATCH] selftests/bpf: Select CONFIG_FUNCTION_ERROR_INJECTION
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+BPF selftests require CONFIG_FUNCTION_ERROR_INJECTION to work. However,
+CONFIG_FUNCTION_ERROR_INJECTION is no longer 'y' by default after recent
+changes. As a result, we are seeing errors like the following from BPF CI:
+
+   bpf_testmod_test_read() is not modifiable
+   __x64_sys_setdomainname is not sleepable
+   __x64_sys_getpgid is not sleepable
+
+Fix this by explicitly selecting CONFIG_FUNCTION_ERROR_INJECTION in the
+selftest config.
+
+Fixes: a4412fdd49dc ("error-injection: Add prompt for function error injection")
+Reported-by: Daniel Müller <deso@posteo.net>
+Signed-off-by: Song Liu <song@kernel.org>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+Acked-by: Daniel Müller <deso@posteo.net>
+Link: https://lore.kernel.org/bpf/20221213220500.3427947-1-song@kernel.org
+Signed-off-by: Daniel Müller <deso@posteo.net>
+---
+ tools/testing/selftests/bpf/config | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/testing/selftests/bpf/config b/tools/testing/selftests/bpf/config
+index 612f69..63cd4a 100644
+--- a/tools/testing/selftests/bpf/config
++++ b/tools/testing/selftests/bpf/config
+@@ -16,6 +16,7 @@ CONFIG_CRYPTO_USER_API_HASH=y
+ CONFIG_DYNAMIC_FTRACE=y
+ CONFIG_FPROBE=y
+ CONFIG_FTRACE_SYSCALLS=y
++CONFIG_FUNCTION_ERROR_INJECTION=y
+ CONFIG_FUNCTION_TRACER=y
+ CONFIG_GENEVE=y
+ CONFIG_IKCONFIG=y
+-- 
+2.30.2
+


### PR DESCRIPTION
Similar to what we did for vmtest [0], libbpf needs the patch setting CONFIG_FUNCTION_ERROR_INJECTION in CI. Add it.

[0] https://github.com/kernel-patches/vmtest/pull/181

Signed-off-by: Daniel Müller <deso@posteo.net>