### PR TITLE
sync: Remove "git format-patch" signature (version) from cover letter

### DIFF
--- a/scripts/sync-kernel.sh
+++ b/scripts/sync-kernel.sh
@@ -260,7 +260,7 @@ if ((${COMMIT_CNT} <= 0)); then
 fi
 
 # Exclude baseline commit and generate nice cover letter with summary
-git format-patch ${SQUASH_BASE_TAG}..${SQUASH_TIP_TAG} --cover-letter -o ${TMP_DIR}/patches
+git format-patch --no-signature ${SQUASH_BASE_TAG}..${SQUASH_TIP_TAG} --cover-letter -o ${TMP_DIR}/patches
 
 # Now is time to re-apply libbpf-related linux patches to libbpf repo
 cd_to ${LIBBPF_REPO}


### PR DESCRIPTION
Minor PR to suggest removing that Git version number from the cover letters generated with `git format-patch` when syncing with kernel.

Reference: https://git-scm.com/docs/git-format-patch#Documentation/git-format-patch.txt---no-signatureltsignaturegt

Tested successfully when syncing bpftool (https://github.com/libbpf/bpftool/commit/d10e1e1f89db4d71c9beb4eebcd4d025b3f853de).
