### PR TITLE
ci: Update default llvm version to 17

### DIFF
--- a/.github/actions/build-selftests/build_selftests.sh
+++ b/.github/actions/build-selftests/build_selftests.sh
@@ -8,7 +8,7 @@ source ${THISDIR}/helpers.sh
 
 foldable start prepare_selftests "Building selftests"
 
-LLVM_VER=16
+LLVM_VER=17
 LIBBPF_PATH="${REPO_ROOT}"
 
 PREPARE_SELFTESTS_SCRIPT=${THISDIR}/prepare_selftests-${KERNEL}.sh


### PR DESCRIPTION
Currently, CI is unable to locate llvm-16 on
aarch64/gcc, aarch64/llvm-16, and s390x/gcc [0].

This change upgrades the default llvm version to 17.

[0] https://github.com/kernel-patches/bpf/actions/runs/4040302668

Signed-off-by: Joanne Koong <joannekoong@gmail.com>