### PR TITLE
README: Clarification on how to handle header files in include/

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ kernel. You'll need:
   - kernel built with `CONFIG_DEBUG_INFO_BTF=y` option;
   - you can check if your kernel has BTF built-in by looking for
     `/sys/kernel/btf/vmlinux` file:
-  
+
 ```shell
 $ ls -la /sys/kernel/btf/vmlinux
 -r--r--r--. 1 root root 3541561 Jun  2 18:16 /sys/kernel/btf/vmlinux
 ```
-  
+
 To develop and build BPF programs, you'll need Clang/LLVM 10+. The following
 distributions have Clang/LLVM 10+ packaged by default:
   - Fedora 32+
@@ -175,10 +175,11 @@ bpf-next to Github sync
 All the gory details of syncing can be found in `scripts/sync-kernel.sh`
 script.
 
-Some header files in this repo (`include/linux/*.h`) are reduced versions of
-their counterpart files at
+Some header files in this repo (`include/uapi/linux/*.h`) are copied from
 [bpf-next](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/)'s
-`tools/include/linux/*.h` to make compilation successful.
+`tools/uapi/include/linux/*.h` to make compilation successful. sync-kernel.sh
+tracks these headers in array `PATH_MAP` so that they are updated by the
+automation.
 
 License
 =======


### PR DESCRIPTION
The header files should not be reduced versions. And they should be sync'ed by sync-kernel.sh.

Also, clarify that this rule applies to headers in include/uapi/linux/.