### PR TITLE
ci: start using llvm-17 now

### DIFF
--- a/.github/actions/build-selftests/build_selftests.sh
+++ b/.github/actions/build-selftests/build_selftests.sh
@@ -11,7 +11,7 @@ foldable start prepare_selftests "Building selftests"
 LIBBPF_PATH="${REPO_ROOT}"
 
 llvm_default_version() {
-	echo "16"
+	echo "17"
 }
 
 llvm_latest_version() {


### PR DESCRIPTION
LLVM 17 problems were fixed upstream, so switch to using latest v17 in CI.