### PR TITLE
git: add .gitattributes file ignoring assets/ during archiving

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/ export-ignore


### PR DESCRIPTION
We don't need to archive assets/ subdir when packaging libbpf sources in retsnoop and veristat repos. Mark assets/ as export-ignore to skip it.