### PR TITLE
libbtf: allow 128B sized BTF_KIND_INT for LLVM DW_ATE_unsigned_1024

### DIFF
--- a/src/btf.c
+++ b/src/btf.c
@@ -1763,7 +1763,7 @@ int btf__add_int(struct btf *btf, const char *name, size_t byte_sz, int encoding
 	if (!name || !name[0])
 		return libbpf_err(-EINVAL);
 	/* byte_sz must be power of 2 */
-	if (!byte_sz || (byte_sz & (byte_sz - 1)) || byte_sz > 16)
+	if (!byte_sz || (byte_sz & (byte_sz - 1)) || byte_sz > 128)
 		return libbpf_err(-EINVAL);
 	if (encoding & ~(BTF_INT_SIGNED | BTF_INT_CHAR | BTF_INT_BOOL))
 		return libbpf_err(-EINVAL);


### PR DESCRIPTION
Similar to pahole
commit 7d8e829f636f ("btf_encoder: Sanitize non-regular int base type")

We can see some unusual sizes in DW_AT_location expressions, example:
```
0x0e4559e2:     DW_TAG_variable
                  DW_AT_location	(indexed (0xcf) loclist = 0x00436e0e:
                     [0x000000000000002c, 0x0000000000000038): DW_OP_breg8 W8+0, DW_OP_convert (0x0e4360cb) "DW_ATE_unsigned_1024", DW_OP_convert (0x0e4360c6) "DW_ATE_unsigned_32", DW_OP_lit3, DW_OP_and, DW_OP_stack_value, DW_OP_piece 0x8)
                  DW_AT_name	("reg_value")
                  DW_AT_type	(0x0e436189 "uint32_t")
```

The following LLVM IR can reproduce the issue:
```llvm
define i8 @foo() !dbg !7 {
entry:
  call void @llvm.dbg.value(metadata i8 32, metadata !9, metadata !DIExpression(DW_OP_plus, DW_OP_LLVM_convert, 8, DW_ATE_signed, DW_OP_LLVM_convert, 1024, DW_ATE_unsigned, DW_OP_stack_value)), !dbg !11
  ret i8 0, !dbg !12
}

declare void @llvm.dbg.value(metadata, metadata, metadata)

!llvm.dbg.cu = !{!0}
!llvm.module.flags = !{!5, !6}

!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 ", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
!1 = !DIFile(filename: "dbg-foo.c", directory: "/tmp", checksumkind: CSK_MD5, checksum: "b35f80a032deb2a30bc187d564b5a775")
!2 = !{}
!4 = !DIFile(filename: "dbg-bar.c", directory: "/tmp", checksumkind: CSK_MD5, checksum: "9836bb594260d883960455e7d8bc51ea")
!5 = !{i32 2, !"Dwarf Version", i32 5}
!6 = !{i32 2, !"Debug Info Version", i32 3}
!7 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 7, type: !8, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
!8 = !DISubroutineType(types: !2)
!9 = !DILocalVariable(name: "y", scope: !7, file: !1, line: 9, type: !10)
!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
!11 = !DILocation(line: 9, column: 14, scope: !7)
!12 = !DILocation(line: 10, column: 3, scope: !7)
```
```sh
$ llc -filetype=obj -O0 < reduced.ll
$ pahole -J reduced.o
[2] INT DW_ATE_unsigned_1024 Error emitting BTF type
Encountered error while encoding BTF.
```

Link: https://git.kernel.org/pub/scm/devel/pahole/pahole.git/commit/?id=7d8e829f636f47aba2e1b6eda57e74d8e31f733c