### PR TITLE
fix field alignment for struct bpf_iter_attach_opts

### DIFF
--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -726,7 +726,7 @@ LIBBPF_API int bpf_link__update_map(struct bpf_link *link, const struct bpf_map 
 struct bpf_iter_attach_opts {
 	size_t sz; /* size of this struct for forward/backward compatibility */
 	union bpf_iter_link_info *link_info;
-	__u32 link_info_len;
+	size_t link_info_len;
 };
 #define bpf_iter_attach_opts__last_field link_info_len
 


### PR DESCRIPTION
Here's gdb's output:

```
(gdb) ptype/o struct bpf_iter_attach_opts
/* offset      |    size */  type = struct bpf_iter_attach_opts {
/*      0      |       8 */    size_t sz;
/*      8      |       8 */    union bpf_iter_link_info *link_info;
/*     16      |       4 */    __u32 link_info_len;
/* XXX  4-byte padding   */

                               /* total size (bytes):   24 */
                             }
```

When `OPTS_VALID(opt, struct bpf_iter_attach_opts)` it will report the total opt size is 20 (field offset of link_info_len is 16 + sizeof (__u32)).
