### PR TITLE
git: make .gitattributes compatible with git-archive-all action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-assets/ export-ignore
+assets/** export-ignore


### PR DESCRIPTION
As reported by Quentin, using Github Action to archive all submodules (e.g., for retsnoop release packaging) is impacted by it not supporting "<glob>/" pattern in .gitattributes. Use "<glob>/**" instead.

  [0] https://github.com/anakryiko/retsnoop/pull/42#issuecomment-1560797837