### PR TITLE
[vmtest] Dump kconfig before running tests

### DIFF
--- a/ci/vmtest/run_selftests.sh
+++ b/ci/vmtest/run_selftests.sh
@@ -55,6 +55,13 @@ test_verifier() {
 
 foldable end vm_init
 
+foldable start kernel_config "Kconfig"
+
+zcat /proc/config.gz
+
+foldable end kernel_config
+
+
 configs_path=/${PROJECT_NAME}/selftests/bpf
 local_configs_path=${PROJECT_NAME}/vmtest/configs
 DENYLIST=$(read_lists \


### PR DESCRIPTION
This helps troubleshooting by validating what the kconfig of the testing environment is