### PR TITLE
libbpf: fix some typo of hashmap init

### DIFF
--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -80,14 +80,14 @@ struct hashmap {
 	size_t sz;
 };
 
-#define HASHMAP_INIT(hash_fn, equal_fn, ctx) {	\
-	.hash_fn = (hash_fn),			\
-	.equal_fn = (equal_fn),			\
-	.ctx = (ctx),				\
-	.buckets = NULL,			\
-	.cap = 0,				\
-	.cap_bits = 0,				\
-	.sz = 0,				\
+#define HASHMAP_INIT(_hash_fn, _equal_fn, _ctx) {	\
+	.hash_fn = (_hash_fn),				\
+	.equal_fn = (_equal_fn),			\
+	.ctx = (_ctx),					\
+	.buckets = NULL,				\
+	.cap = 0,					\
+	.cap_bits = 0,					\
+	.sz = 0,					\
 }
 
 void hashmap__init(struct hashmap *map, hashmap_hash_fn hash_fn,


### PR DESCRIPTION
rename macro parameters to prevent replacing struct members of hashmap