### PR TITLE
bpf: use local includes inside the library

### DIFF
--- a/src/bpf_tracing.h
+++ b/src/bpf_tracing.h
@@ -2,7 +2,7 @@
 #ifndef __BPF_TRACING_H__
 #define __BPF_TRACING_H__
 
-#include <bpf/bpf_helpers.h>
+#include "bpf_helpers.h"
 
 /* Scan the ARCH passed in from ARCH env variable (see Makefile) */
 #if defined(__TARGET_ARCH_x86)

--- a/src/usdt.bpf.h
+++ b/src/usdt.bpf.h
@@ -4,8 +4,8 @@
 #define __USDT_BPF_H__
 
 #include <linux/errno.h>
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
+#include "bpf_helpers.h"
+#include "bpf_tracing.h"
 
 /* Below types and maps are internal implementation details of libbpf's USDT
  * support and are subjects to change. Also, bpf_usdt_xxx() API helpers should


### PR DESCRIPTION
Today there is no way to include library headers without doing `PREFIX=<some tmp dir> make install` with some prefix to try a new version of the library without installing it globally, my fix allows to do this. And it seems to me that this does not violate the current behavior.