### PR TITLE
ci: update list of tests/subtests for 5.5 kernel

### DIFF
--- a/ci/vmtest/configs/ALLOWLIST-5.5.0
+++ b/ci/vmtest/configs/ALLOWLIST-5.5.0
@@ -32,7 +32,6 @@ raw_tp_writable_test_run
 rdonly_maps
 section_names
 signal_pending
-skeleton
 sockmap_ktls
 sockopt
 spinlock

--- a/ci/vmtest/configs/DENYLIST-5.5.0
+++ b/ci/vmtest/configs/DENYLIST-5.5.0
@@ -3,3 +3,5 @@
 btf			# "size check test", "func (Non zero vlen)"
 tailcalls		# tailcall_bpf2bpf_1, tailcall_bpf2bpf_2, tailcall_bpf2bpf_3
 tc_bpf/tc_bpf_non_root
+sockopt/setsockopt: ignore >PAGE_SIZE optlen
+sockopt/getsockopt: ignore >PAGE_SIZE optlen


### PR DESCRIPTION
Some tests can't succeed on 5.5, which is very old.
