### PR TITLE
Fix Ubuntu package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Distributions packaging libbpf from this mirror:
   - [Gentoo](https://packages.gentoo.org/packages/dev-libs/libbpf)
   - [Debian](https://packages.debian.org/source/sid/libbpf)
   - [Arch](https://archlinux.org/packages/core/x86_64/libbpf/)
-  - [Ubuntu](https://packages.ubuntu.com/source/impish/libbpf)
+  - [Ubuntu](https://packages.ubuntu.com/source/jammy/libbpf)
   - [Alpine](https://pkgs.alpinelinux.org/packages?name=libbpf)
 
 Benefits of packaging from the mirror over packaging from kernel sources:


### PR DESCRIPTION
The old link is no longer available since Ubuntu 21.10 (Impish Indri) reached the end of life. 

This PR updates the link to point to the version of Ubuntu 22.04 (Jammy Jellyfish).

An alternative is to point to the search page to avoid catching the Ubuntu version: https://packages.ubuntu.com/search?keywords=libbpf&searchon=sourcenames