### PR TITLE
ci: give /dev/kvm 0666 permissions inside CI runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,20 @@ jobs:
             runs_on: s390x
             arch: 's390x'
     steps:
+      # Allow CI user to access /dev/kvm (via qemu) w/o group change/relogin
+      # by changing permissions set by udev.
+      - name: Set /dev/kvm permissions
+        shell: bash
+        run: |
+          if [ -e /dev/kvm ]; then
+            echo "/dev/kvm exists, updating permissions"
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+              | sudo tee /etc/udev/rules.d/99-kvm4all.rules > /dev/null
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+          else
+            echo "/dev/kvm does not exist"
+          fi
       - uses: actions/checkout@v3
         name: Checkout
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Starting recently libbpf CI runs started failing with the following error:

```
    ##[group]vm_init - Starting virtual machine...
    Starting VM with 4 CPUs...
    INFO: /dev/kvm exists
    KVM acceleration can be used
    Could not access KVM kernel module: Permission denied
    qemu-system-x86_64: failed to initialize KVM: Permission denied
    ##[error]Process completed with exit code 2.
```

E.g. see [here](https://github.com/libbpf/libbpf/actions/runs/6819530119/job/18547589967?pr=746). The error happens because CI user has not enough rights to access `/dev/kvm`. On a regular machine the solution would be to add user to group `kvm`, however that would require a re-login, which is cumbersome to achieve in CI setting. Instead, use a recipe described [here](https://stackoverflow.com/questions/37300811/android-studio-dev-kvm-device-permission-denied/61984745#61984745) to make udev set `0666` access permissions for `/dev/kvm`.