### PR TITLE
ci: use config.vm for kernel config when present

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -46,6 +46,8 @@ runs:
         cd .kernel
         cat tools/testing/selftests/bpf/config \
             tools/testing/selftests/bpf/config.${{ inputs.arch }} > .config
+        # this file might or mihgt not exist depending on kernel version
+        cat tools/testing/selftests/bpf/config.vm >> .config || :
         make olddefconfig && make prepare
         cd -
         foldable end


### PR DESCRIPTION
Recent kernel commit [0] changed selftests config snippets structure by extracting VM specific options to the file `config.vm`. This file has to be used in `.github/actions/vmtest/action.yml` at step `Prepare to build BPF selftests`, otherwise drivers necessary for e.g. root file system access are not compiled into the kernel, leading to CI failures like [1].

[0] b0cf0dcde8ca ("selftests/bpf: Consolidate VIRTIO/9P configs in config.vm file")
[1] https://github.com/libbpf/libbpf/actions/runs/6830439839/job/18578379328?pr=747