### PR TITLE
ci: don't set /dev/kvm permissions when CI user is root

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,13 @@ jobs:
         shell: bash
         run: |
           if [ -e /dev/kvm ]; then
-            echo "/dev/kvm exists, updating permissions"
-            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-              | sudo tee /etc/udev/rules.d/99-kvm4all.rules > /dev/null
-            sudo udevadm control --reload-rules
-            sudo udevadm trigger --name-match=kvm
+            echo "/dev/kvm exists"
+            if [ $(id -u) != 0 ]; then
+              echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+                | sudo tee /etc/udev/rules.d/99-kvm4all.rules > /dev/null
+              sudo udevadm control --reload-rules
+              sudo udevadm trigger --name-match=kvm
+            fi
           else
             echo "/dev/kvm does not exist"
           fi


### PR DESCRIPTION
s390 tests are executed on selfhosted runner using root user, avoid setting `/dev/kvm` permissions in such case.
This should fix CI failures like [0].
(Still necessary for x86 tests executed on standard github runners).

[0] https://github.com/libbpf/libbpf/actions/runs/6898545987/job/18768732980?pr=752

Fixes: 168630f852d0 ("ci: give /dev/kvm 0666 permissions inside CI runner")