### PR TITLE
ci: disable selftests failing on LATEST and 5.5 kernels

### DIFF
--- a/ci/vmtest/configs/ALLOWLIST-5.5.0
+++ b/ci/vmtest/configs/ALLOWLIST-5.5.0
@@ -33,7 +33,6 @@ rdonly_maps
 section_names
 signal_pending
 sockmap_ktls
-sockopt
 spinlock
 stacktrace_map
 stacktrace_map_raw_tp

--- a/ci/vmtest/configs/DENYLIST-5.5.0
+++ b/ci/vmtest/configs/DENYLIST-5.5.0
@@ -3,5 +3,3 @@
 btf			# "size check test", "func (Non zero vlen)"
 tailcalls		# tailcall_bpf2bpf_1, tailcall_bpf2bpf_2, tailcall_bpf2bpf_3
 tc_bpf/tc_bpf_non_root
-sockopt/setsockopt: ignore >PAGE_SIZE optlen
-sockopt/getsockopt: ignore >PAGE_SIZE optlen

--- a/ci/vmtest/configs/DENYLIST-latest
+++ b/ci/vmtest/configs/DENYLIST-latest
@@ -3,3 +3,7 @@ empty_skb # waiting the fix in bpf tree to make it to bpf-next
 bpf_nf/tc-bpf-ct # test consistently failing on x86: https://github.com/libbpf/libbpf/pull/698#issuecomment-1590341200
 bpf_nf/xdp-ct   # test consistently failing on x86: https://github.com/libbpf/libbpf/pull/698#issuecomment-1590341200
 kprobe_multi_bench_attach # suspected to cause crashes in CI
+find_vma # test consistently fails on latest kernel, see https://github.com/libbpf/libbpf/issues/754 for details
+bpf_cookie/perf_event
+send_signal/send_signal_nmi
+send_signal/send_signal_nmi_thread


### PR DESCRIPTION
This test started to fail on LATEST kernel, e.g. see [0]. There are no apparent issues with it on main kernel CI. Link [1] has some details. Overall, it looks like perf event expected by sub-test test_find_vma_pe() of
prog_tests/find_vma.c is never delivered.

[0] https://github.com/libbpf/libbpf/actions/runs/6904382140/job/18784917164
[1] https://github.com/libbpf/libbpf/issues/754