### PR TITLE
ci: move /dev/kvm permissions setup from to actions/vmtest.yml

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -16,6 +16,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Allow CI user to access /dev/kvm (via qemu) w/o group change/relogin
+    # by changing permissions set by udev.
+    - name: Set /dev/kvm permissions
+      shell: bash
+      run: |
+        if [ -e /dev/kvm ]; then
+          echo "/dev/kvm exists"
+          if [ $(id -u) != 0 ]; then
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+              | sudo tee /etc/udev/rules.d/99-kvm4all.rules > /dev/null
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+          fi
+        else
+          echo "/dev/kvm does not exist"
+        fi
     # setup environment
     - name: Setup environment
       uses: libbpf/ci/setup-build-env@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,22 +31,6 @@ jobs:
             runs_on: s390x
             arch: 's390x'
     steps:
-      # Allow CI user to access /dev/kvm (via qemu) w/o group change/relogin
-      # by changing permissions set by udev.
-      - name: Set /dev/kvm permissions
-        shell: bash
-        run: |
-          if [ -e /dev/kvm ]; then
-            echo "/dev/kvm exists"
-            if [ $(id -u) != 0 ]; then
-              echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-                | sudo tee /etc/udev/rules.d/99-kvm4all.rules > /dev/null
-              sudo udevadm control --reload-rules
-              sudo udevadm trigger --name-match=kvm
-            fi
-          else
-            echo "/dev/kvm does not exist"
-          fi
       - uses: actions/checkout@v3
         name: Checkout
       - uses: ./.github/actions/setup


### PR DESCRIPTION
The vmtest action is used from by workflows: test, pahole, ondemand. At the same time vmtest action requires valid access rights to /dev/kvm and is the only action that uses it.
This commit moves /dev/kvm permissions setup from test workflow to vmtest action, in order to make sure that setup logic is shared by all workflows that run vmtest.
Should fix CI failures like [1].

[1] https://github.com/libbpf/libbpf/actions/runs/7104762048/job/19340484589
