### PR TITLE
ci: allowlist arg_tag_ctx tests for validate __arg_ctx fallback logic

### DIFF
--- a/ci/vmtest/configs/ALLOWLIST-5.5.0
+++ b/ci/vmtest/configs/ALLOWLIST-5.5.0
@@ -42,8 +42,12 @@ task_fd_query_tp
 tc_bpf
 tcp_estats
 tcp_rtt
+test_global_funcs/arg_tag_ctx*
 tp_attach_query
 usdt/urand_pid_attach
+verifier_global_subprogs/arg_tag_ctx_raw_tp
+verifier_global_subprogs/arg_tag_ctx_kprobe
+verifier_global_subprogs/arg_tag_ctx_perf
 xdp
 xdp_noinline
 xdp_perf


### PR DESCRIPTION
Allowlist test_global_funcs/arg_tag_ctx* tests to validate libbpf's logic for rewriting __arg_ctx globl subprog argument types on kernels that don't natively support __arg_ctx.
