### PR TITLE
ci: Pass arch parameter to setup-build-env

### DIFF
--- a/.github/actions/vmtest/action.yml
+++ b/.github/actions/vmtest/action.yml
@@ -37,6 +37,7 @@ runs:
       uses: libbpf/ci/setup-build-env@main
       with:
         pahole: ${{ inputs.pahole }}
+        arch: ${{ inputs.arch }}
     # 1. download CHECKPOINT kernel source
     - name: Get checkpoint commit
       shell: bash


### PR DESCRIPTION
Since https://github.com/libbpf/ci/commit/1bc40aecb32f1e0f0dc2fff87e7c91b4d5fe03c5 arch parameter needs to be passed to `setup-build-env`