### PR TITLE
include: fix BPF_CALL_REL definition

### DIFF
--- a/include/linux/filter.h
+++ b/include/linux/filter.h
@@ -39,6 +39,7 @@
 
 #define BPF_CALL_REL(DST)					\
 	((struct bpf_insn) {					\
+		.code = BPF_JMP | BPF_CALL,			\
 		.dst_reg = 0,					\
 		.src_reg = BPF_PSEUDO_CALL,			\
 		.off = 0,					\


### PR DESCRIPTION
Fix our Github-specific definition of BPF_CALL_REL macro. It was missing the code part.

Thank you for considering a contribution!

Please note that the `libbpf` authoritative source code is developed as part of bpf-next Linux source tree under tools/lib/bpf subdirectory and is periodically synced to Github. As such, all the libbpf changes should be sent to BPF mailing list, please don't open PRs here unless you are changing Github-specific parts of libbpf (e.g., Github-specific Makefile).
