### PR TITLE
ci: bump checkout action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           - name: gcc-12
             target: RUN_GCC12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
       - uses: ./.github/actions/setup
         name: Setup
@@ -63,7 +63,7 @@ jobs:
           - arch: s390x
           - arch: x86
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
       - uses: ./.github/actions/setup
         name: Pre-Setup

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'libbpf/libbpf'
     name: Coverity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Run coverity
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         env:

--- a/.github/workflows/ondemand.yml
+++ b/.github/workflows/ondemand.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     name: vmtest with customized pahole/Kernel
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/vmtest
         with:

--- a/.github/workflows/pahole.yml
+++ b/.github/workflows/pahole.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       STAGING: tmp.master
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/vmtest
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
             runs_on: s390x
             arch: 's390x'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
       - uses: ./.github/actions/setup
         name: Setup


### PR DESCRIPTION
Due to the transition from Node 16 to Node 20, the checkout action needs to be updated to v4.

More info: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This solves the following annotations: https://github.com/libbpf/libbpf/actions/runs/8511843538
