### PR TITLE
ci: bump run-on-arch action to v2.7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       - run: source /tmp/ci_setup && sudo -E $CI_ROOT/managers/ubuntu.sh
         if: matrix.arch == 'x86'
         name: Setup
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.7.1
         name: Build in docker
         if: matrix.arch != 'x86'
         with:


### PR DESCRIPTION
More info: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

#792 didn't silence all the annotations: https://github.com/libbpf/libbpf/actions/runs/8527504244