### PR TITLE
sync: Sync .mailmap entries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,16 @@
+Alexei Starovoitov <ast@kernel.org> <alexei.starovoitov@gmail.com>
+Antoine Tenart <atenart@kernel.org> <antoine.tenart@bootlin.com>
+Björn Töpel <bjorn@kernel.org> <bjorn.topel@intel.com>
+Changbin Du <changbin.du@intel.com> <changbin.du@gmail.com>
+Colin Ian King <colin.i.king@gmail.com> <colin.king@canonical.com>
+Dan Carpenter <error27@gmail.com> <dan.carpenter@oracle.com>
+Geliang Tang <geliang@kernel.org> <geliang.tang@suse.com>
+Herbert Xu <herbert@gondor.apana.org.au>
+Jakub Kicinski <kuba@kernel.org> <jakub.kicinski@netronome.com>
+Leo Yan <leo.yan@linux.dev> <leo.yan@linaro.org>
+Mark Starovoytov <mstarovo@pm.me> <mstarovoitov@marvell.com>
+Maxim Mikityanskiy <maxtram95@gmail.com> <maximmi@mellanox.com>
+Maxim Mikityanskiy <maxtram95@gmail.com> <maximmi@nvidia.com>
+Quentin Monnet <qmo@kernel.org> <quentin@isovalent.com>
+Quentin Monnet <qmo@kernel.org> <quentin.monnet@netronome.com>
+Vadim Fedorenko <vadim.fedorenko@linux.dev> <vfedorenko@novek.ru>

--- a/scripts/mailmap-update.sh
+++ b/scripts/mailmap-update.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu
+
+usage () {
+    echo "USAGE: ./mailmap-update.sh <libbpf-repo> <linux-repo>"
+    exit 1
+}
+
+LIBBPF_REPO="${1-""}"
+LINUX_REPO="${2-""}"
+
+if [ -z "${LIBBPF_REPO}" ] || [ -z "${LINUX_REPO}" ]; then
+    echo "Error: libbpf or linux repos are not specified"
+    usage
+fi
+
+LIBBPF_MAILMAP="${LIBBPF_REPO}/.mailmap"
+LINUX_MAILMAP="${LINUX_REPO}/.mailmap"
+
+tmpfile="$(mktemp)"
+cleanup() {
+    rm -f "${tmpfile}"
+}
+trap cleanup EXIT
+
+grep_lines() {
+    local pattern="$1"
+    local file="$2"
+    grep "${pattern}" "${file}" || true
+}
+
+while read -r email; do
+    grep_lines "${email}$" "${LINUX_MAILMAP}" >> "${tmpfile}"
+done < <(git log --format='<%ae>' | sort -u)
+
+sort -u "${tmpfile}" > "${LIBBPF_MAILMAP}"

--- a/scripts/sync-kernel.sh
+++ b/scripts/sync-kernel.sh
@@ -352,4 +352,10 @@ else
 	esac
 fi
 
+echo "Regenerating .mailmap..."
+cd_to "${LINUX_REPO}"
+git checkout "${TIP_SYM_REF}"
+cd_to "${LIBBPF_REPO}"
+"${LIBBPF_REPO}"/scripts/mailmap-update.sh "${LIBBPF_REPO}" "${LINUX_REPO}"
+
 cleanup


### PR DESCRIPTION
The kernel repository has a .mailmap file to remap author names and email addresses to their desired format in Git logs (for details, see [gitmailmap documentation][0]). Alas, this is only visible for author information when looking at the logs locally, as GitHub [does not support mailmaps][1] at the moment.

This commit adds a .mailmap file for libbpf, automatically generated from the kernel's version. The script to generate the .mailmap is added, too: it works by grepping email addresses from authors in the repository, and collecting all lines ending with this address in the kernel's .mailmap - in other words, all lines where this address is used as a pattern for a remapping.

To keep the .mailmap up-to-date, add a call to the script to sync-kernel.sh.

[0]: https://git-scm.com/docs/gitmailmap
[1]: https://github.com/orgs/community/discussions/22518
