### PR TITLE
sync: Commit .mailmap changes from script when sync-ing repo

### DIFF
--- a/scripts/sync-kernel.sh
+++ b/scripts/sync-kernel.sh
@@ -295,6 +295,22 @@ Latest changes to BPF helper definitions.
 " -- src/bpf_helper_defs.h
 fi
 
+echo "Regenerating .mailmap..."
+cd_to "${LINUX_REPO}"
+git checkout "${TIP_SYM_REF}"
+cd_to "${LIBBPF_REPO}"
+"${LIBBPF_REPO}"/scripts/mailmap-update.sh "${LIBBPF_REPO}" "${LINUX_REPO}"
+# if anything changed, commit it
+mailmap_changes=$(git status --porcelain .mailmap | wc -l)
+if ((${mailmap_changes} == 1)); then
+	git add .mailmap
+	git commit -s -m "sync: update .mailmap
+
+Update .mailmap based on libbpf's list of contributors and on the latest
+.mailmap version in the upstream repository.
+" -- .mailmap
+fi
+
 # Use generated cover-letter as a template for "sync commit" with
 # baseline and checkpoint commits from kernel repo (and leave summary
 # from cover letter intact, of course)
@@ -351,11 +367,5 @@ else
 			exit 4
 	esac
 fi
-
-echo "Regenerating .mailmap..."
-cd_to "${LINUX_REPO}"
-git checkout "${TIP_SYM_REF}"
-cd_to "${LIBBPF_REPO}"
-"${LIBBPF_REPO}"/scripts/mailmap-update.sh "${LIBBPF_REPO}" "${LINUX_REPO}"
 
 cleanup


### PR DESCRIPTION
In commit 4794f18bf468 ("sync: Sync .mailmap entries"), we updated the sync-up script to automatically update libbpf's .mailmap; however, the script would not take care of committing the changes. Let's address this.

The code is copied and adapted from the part where we commit changes to src/bpf_helper_defs.h.

Follow-up to https://github.com/libbpf/libbpf/pull/800#issuecomment-2085813085.