### PR TITLE
ci: revert switching to ubuntu-latest for pahole-staging workflow

### DIFF
--- a/.github/workflows/pahole.yml
+++ b/.github/workflows/pahole.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   vmtest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Kernel LATEST + staging pahole
     env:
       STAGING: tmp.master


### PR DESCRIPTION
pahole staging workflow is using the same old VM image as BPF selftests stages. It doesn't have recent enough glibc, so we can't yet switch to newer Ubuntu, unfortunately.