### PR TITLE
ci: run test on Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,16 @@ jobs:
       matrix:
         include:
           - kernel: 'LATEST'
-            runs_on: ubuntu-20.04
+            runs_on: ubuntu-24.04
             arch: 'x86_64'
           - kernel: '5.5.0'
-            runs_on: ubuntu-20.04
+            runs_on: ubuntu-24.04
             arch: 'x86_64'
           - kernel: '4.9.0'
-            runs_on: ubuntu-20.04
+            runs_on: ubuntu-24.04
             arch: 'x86_64'
           - kernel: 'LATEST'
-            runs_on: ["s390x", "docker-main"]
+            runs_on: ["s390x", "docker-noble-main"]
             arch: 's390x'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Migrate builds to use Ubuntu 24.04 runners.
vmtest will need to run on Ubuntu 20.04 rootfs too (see https://github.com/libbpf/ci/pull/136)