### PR TITLE
ci: take into account common local DENYLIST/ALLOWLIST

### DIFF
--- a/ci/vmtest/run_selftests.sh
+++ b/ci/vmtest/run_selftests.sh
@@ -67,12 +67,14 @@ local_configs_path=${PROJECT_NAME}/vmtest/configs
 DENYLIST=$(read_lists \
 	"$configs_path/DENYLIST" \
 	"$configs_path/DENYLIST.${ARCH}" \
+	"$local_configs_path/DENYLIST" \
 	"$local_configs_path/DENYLIST-${KERNEL}" \
 	"$local_configs_path/DENYLIST-${KERNEL}.${ARCH}" \
 )
 ALLOWLIST=$(read_lists \
 	"$configs_path/ALLOWLIST" \
 	"$configs_path/ALLOWLIST.${ARCH}" \
+	"$local_configs_path/ALLOWLIST" \
 	"$local_configs_path/ALLOWLIST-${KERNEL}" \
 	"$local_configs_path/ALLOWLIST-${KERNEL}.${ARCH}" \
 )


### PR DESCRIPTION
Similar to naming convention in BPF selftests.