### PR TITLE
ci: get rid of s390x kernel tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,6 @@ jobs:
           - kernel: '4.9.0'
             runs_on: ubuntu-24.04
             arch: 'x86_64'
-          - kernel: 'LATEST'
-            runs_on: ["s390x", "docker-noble-main"]
-            arch: 's390x'
     steps:
       - uses: actions/checkout@v4
         name: Checkout


### PR DESCRIPTION
Kernel/libbpf code is very well tested on s390x in BPF CI, so get rid of it here as it often is a source of trouble and noise, without really benefiting us much.