### PR TITLE
ci: remove dependency on run-on-arch-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,31 +61,32 @@ jobs:
           - arch: aarch64
           - arch: ppc64le
           - arch: s390x
-          - arch: x86
+          - arch: amd64
     steps:
       - uses: actions/checkout@v4
         name: Checkout
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
+
       - uses: ./.github/actions/setup
         name: Pre-Setup
+
       - run: source /tmp/ci_setup && sudo -E $CI_ROOT/managers/ubuntu.sh
-        if: matrix.arch == 'x86'
+        if: matrix.arch == 'amd64'
         name: Setup
-      - uses: uraimo/run-on-arch-action@v2.8.1
-        name: Build in docker
-        if: matrix.arch != 'x86'
-        with:
-          distro:
-            ubuntu22.04
-          arch:
-            ${{ matrix.arch }}
-          setup:
-            cp /tmp/ci_setup $GITHUB_WORKSPACE
-          dockerRunArgs: |
-            --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}"
-          shell: /bin/bash
-          install: |
-            export DEBIAN_FRONTEND=noninteractive
-            export TZ="America/Los_Angeles"
-            apt-get update -y
-            apt-get install -y tzdata build-essential sudo
-          run: source ${GITHUB_WORKSPACE}/ci_setup && $CI_ROOT/managers/ubuntu.sh
+
+      - name: Build in docker
+        if: matrix.arch != 'amd64'
+        run: |
+          cp /tmp/ci_setup ${GITHUB_WORKSPACE}
+          docker run --rm \
+                 --platform linux/${{ matrix.arch }} \
+                 -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} \
+                 -e GITHUB_WORKSPACE=${GITHUB_WORKSPACE} \
+                 -w /ci/workspace \
+                 ubuntu:noble \
+                 ${GITHUB_WORKSPACE}/ci/build-in-docker.sh
+

--- a/ci/build-in-docker.sh
+++ b/ci/build-in-docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+export TZ="America/Los_Angeles"
+
+apt-get update -y
+apt-get install -y tzdata build-essential sudo
+source ${GITHUB_WORKSPACE}/ci_setup
+
+$CI_ROOT/managers/ubuntu.sh
+
+exit 0


### PR DESCRIPTION
run-on-arch-action is simply a wrapper around docker. There is no value in using it in libbpf, as it is not complicated to run non-native arch docker images directly on github-hosted runners.

Docker relies on qemu-user-static installed on the system to emulate different architectures.

Recently there were various reports about multi-arch docker builds failing with seemingly random issues, and it appears to boil down to qemu [1]. I stumbled on this problem while updating s390x runners [2] for BPF CI, and setting up more recent version of qemu helped.

This change addresses recent build failures on s390x and ppc64le.

[1] https://github.com/docker/setup-qemu-action/issues/188
[2] https://github.com/kernel-patches/runner/pull/69
[3] https://docs.docker.com/build/buildkit/#getting-started