### PR TITLE
libbpf: add check if kernel supports kind flag and fix the bitfield m…

### DIFF
--- a/src/libbpf_internal.h
+++ b/src/libbpf_internal.h
@@ -380,6 +380,8 @@ enum kern_feature_id {
 	FEAT_ARG_CTX_TAG,
 	/* Kernel supports '?' at the front of datasec names */
 	FEAT_BTF_QMARK_DATASEC,
+    /* Kernel supports kind flag */
+    FEAT_BTF_TYPE_KIND_FLAG,
 	__FEAT_CNT,
 };
 


### PR DESCRIPTION
The second issue in addition to https://github.com/libbpf/libbpf/pull/892 is a kind flag.

Let's say we're compiling the BPF object on new kernel with new compiler. It's with 99% percent chance that compiler will use this `kind flag` ([docs](https://github.com/torvalds/linux/blob/v4.19/kernel/bpf/btf.c#L166)) which [changes the behavior of bitfield members relocation](https://docs.kernel.org/bpf/btf.html#btf-kind-struct).

But of we're loading on old kernels that have no support of this it will fail in multiple places
- The type metadata check ([BTF_INFO_MASK prohibits 31d bit](https://github.com/torvalds/linux/blob/v4.19/kernel/bpf/btf.c#L166))
- [Integral bitfield verification](https://github.com/torvalds/linux/blob/609706855d90bcab6080ba2cd030b9af322a1f0c/kernel/bpf/btf.c#L2133). Because kernel waits for a offset-only encoding.

What this PR proposes:
- The feature check whether kernel supports the kind flag or not
- Kind flag sanitizing 
- Struct bitfield members sanitizing by generation a proper replacement the type of bitfield with corresponding integer type  

I assume that there is a more elegant way to do it. Maybe it could be better to write an API like `btf_int` like in kernel to avoid code like [this](https://github.com/libbpf/libbpf/compare/master...T3RR7:libbpf:kind-flag-support-check-and-fix?expand=1#diff-ac82747bd450e8e5e0805a99d6c24afa9fcbfcddffbce5aa3288b2edabe17419R3275). Anyway, it works.