### PR TITLE
sync: uapi: move constants from <linux/kernel.h> to <linux/const.h>

### DIFF
--- a/include/uapi/linux/netlink.h
+++ b/include/uapi/linux/netlink.h
@@ -2,7 +2,7 @@
 #ifndef __LINUX_NETLINK_H
 #define __LINUX_NETLINK_H
 
-#include <linux/kernel.h>
+#include <linux/const.h>
 #include <linux/socket.h> /* for __kernel_sa_family_t */
 #include <linux/types.h>
 


### PR DESCRIPTION
This change was applied to the kernel tree in 2020 afaict, to fix redefinition issues with musl-libc.

I ran into this issue while building with the headers included with libbpf, since it seems they were not synced since then.

Signed-off-by: Yureka Lilian <yuka@yuka.dev>