### PR TITLE
added __poll_t typedef needed for Android/Termux, where linux/types.h…

### DIFF
--- a/include/linux/types.h
+++ b/include/linux/types.h
@@ -30,4 +30,8 @@ struct list_head {
 	struct list_head *next, *prev;
 };
 
+/* the following is needed on Android/Termux, where this linux/types.h is included by other include files */
+typedef unsigned __bitwise __poll_t;
+
+
 #endif


### PR DESCRIPTION
… is included (indirectly) by sys/epoll.h which depends on this definition

See issue #925