### PR TITLE
Redefining the macro __PT_SP_REG

### DIFF
--- a/src/bpf_tracing.h
+++ b/src/bpf_tracing.h
@@ -311,7 +311,7 @@ struct pt_regs___arm64 {
 #define __PT_RET_REG regs[31]
 #define __PT_FP_REG __unsupported__
 #define __PT_RC_REG gpr[3]
-#define __PT_SP_REG sp
+#define __PT_SP_REG gpr[1]
 #define __PT_IP_REG nip
 
 #elif defined(bpf_target_sparc)


### PR DESCRIPTION
Redefined macro definition _**__PT_SP_REG**_ since sp is undefined in ppc64le.
Because of undefined sp, **retsnoop** package is failing under **ppc64le** in **fedora** side.
Fixing the mentioned macro definition will resolves the issue.
