### PR TITLE
elf_resolve_syms_offsets: clear err on happy flow

### DIFF
--- a/src/elf.c
+++ b/src/elf.c
@@ -486,6 +486,7 @@ int elf_resolve_syms_offsets(const char *binary_path, int cnt,
 		goto out;
 	}
 
+	err = 0;
 	*poffsets = offsets;
 
 out:


### PR DESCRIPTION
Fix a bug where elf_resolve_syms_offsets returned an error although it successfully resolved all symbols because .symtab wasn't found.

Fixed #953 