### PR TITLE
libbpf: Fix wrong btf_array() operand in BTF dedup comparison

### DIFF
--- a/src/btf.c
+++ b/src/btf.c
@@ -4549,7 +4549,7 @@ recur:
 			return false;
 
 		a1 = btf_array(t1);
-		a2 = btf_array(t1);
+		a2 = btf_array(t2);
 
 		if (a1->index_type != a2->index_type &&
 		    !btf_dedup_identical_types(d, a1->index_type, a2->index_type, depth - 1))


### PR DESCRIPTION
## Summary
Fix a copy-paste bug in `btf_dedup_identical_types()` when handling `BTF_KIND_ARRAY`: the second `struct btf_array` was taken from `t1` instead of `t2`, so index and element type checks could compare the wrong metadata.

## Change
- `a2 = btf_array(t1)` → `a2 = btf_array(t2)`