### PR TITLE
libbpf: Fix ENODATA handling in struct/union check_zero path

### DIFF
--- a/src/btf_dump.c
+++ b/src/btf_dump.c
@@ -2468,7 +2468,7 @@ static int btf_dump_type_data_check_zero(struct btf_dump *d,
 			bit_sz = btf_member_bitfield_size(t, i);
 			err = btf_dump_type_data_check_zero(d, mtype, m->type, data + moffset / 8,
 							    moffset % 8, bit_sz);
-			if (err != ENODATA)
+			if (err != -ENODATA)
 				return err;
 		}
 		return -ENODATA;


### PR DESCRIPTION
## Summary
`btf_dump_type_data_check_zero()` returns negative errno-style values (e.g. `-ENODATA`). In the `BTF_KIND_STRUCT` / `BTF_KIND_UNION` path, the member loop compared `err` to `ENODATA` instead of `-ENODATA`, while the array branch already used `-ENODATA`. That mismatch broke the intended “continue when this subtree is empty” behavior.

## Change
- `if (err != ENODATA)` → `if (err != -ENODATA)`