### PR TITLE
ci: denylist flaky 'file_reader' selftest

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -15,3 +15,4 @@ tc_redirect		  # enough is enough, banned for life for flakiness
 map_kptr                  # kprobe rcu_tasks_trace_postgp not available in VM kernel
 test_profiler             # kretprobe do_filp_open not available in VM kernel
 sockmap_basic/sockmap udp multi channels  # flaky in CI
+file_reader  # flaky: MADV_PAGEOUT page stays resident in CI VM, expected EFAULT never fires


### PR DESCRIPTION
file_reader/on_open_expect_fault expects MADV_PAGEOUT to evict the file page so a non-sleepable bpf_dynptr_read() returns -EFAULT. In the CI VM the page is still resident at read time, the read succeeds, run_success stays 0 and the subtest fails on every nightly run (all three flavors). Already denied in the kernel-patches CI; mirror it in the bundled denylist so libbpf-ci goes green again.