### PR TITLE
Add maxactive field to bpf_kprobe_opts for legacy kprobes

### DIFF
--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -11690,8 +11690,14 @@ static void gen_probe_legacy_event_name(char *buf, size_t buf_sz,
 }
 
 static int add_kprobe_event_legacy(const char *probe_name, bool retprobe,
-				   const char *kfunc_name, size_t offset)
+				   const char *kfunc_name, size_t offset,
+				   int maxactive)
 {
+	if (retprobe && maxactive > 0)
+		return append_to_file(tracefs_kprobe_events(), "r%d:%s/%s %s+0x%zx",
+				      maxactive, "kretprobes",
+				      probe_name, kfunc_name, offset);
+
 	return append_to_file(tracefs_kprobe_events(), "%c:%s/%s %s+0x%zx",
 			      retprobe ? 'r' : 'p',
 			      retprobe ? "kretprobes" : "kprobes",
@@ -11715,13 +11721,14 @@ static int determine_kprobe_perf_type_legacy(const char *probe_name, bool retpro
 }
 
 static int perf_event_kprobe_open_legacy(const char *probe_name, bool retprobe,
-					 const char *kfunc_name, size_t offset, int pid)
+					 const char *kfunc_name, size_t offset, int pid,
+					 int maxactive)
 {
 	const size_t attr_sz = sizeof(struct perf_event_attr);
 	struct perf_event_attr attr;
 	int type, pfd, err;
 
-	err = add_kprobe_event_legacy(probe_name, retprobe, kfunc_name, offset);
+	err = add_kprobe_event_legacy(probe_name, retprobe, kfunc_name, offset, maxactive);
 	if (err < 0) {
 		pr_warn("failed to add legacy kprobe event for '%s+0x%zx': %s\n",
 			kfunc_name, offset,
@@ -11808,7 +11815,7 @@ int probe_kern_syscall_wrapper(int token_fd)
 		char probe_name[MAX_EVENT_NAME_LEN];
 
 		gen_probe_legacy_event_name(probe_name, sizeof(probe_name), syscall_name, 0);
-		if (add_kprobe_event_legacy(probe_name, false, syscall_name, 0) < 0)
+		if (add_kprobe_event_legacy(probe_name, false, syscall_name, 0, 0) < 0)
 			return 0;
 
 		(void)remove_kprobe_event_legacy(probe_name, false);
@@ -11827,7 +11834,7 @@ bpf_program__attach_kprobe_opts(const struct bpf_program *prog,
 	struct bpf_link *link;
 	size_t offset;
 	bool retprobe, legacy;
-	int pfd, err;
+	int pfd, err, maxactive;
 
 	if (!OPTS_VALID(opts, bpf_kprobe_opts))
 		return libbpf_err_ptr(-EINVAL);
@@ -11835,6 +11842,7 @@ bpf_program__attach_kprobe_opts(const struct bpf_program *prog,
 	attach_mode = OPTS_GET(opts, attach_mode, PROBE_ATTACH_MODE_DEFAULT);
 	retprobe = OPTS_GET(opts, retprobe, false);
 	offset = OPTS_GET(opts, offset, 0);
+	maxactive = OPTS_GET(opts, maxactive, 0);
 	pe_opts.bpf_cookie = OPTS_GET(opts, bpf_cookie, 0);
 
 	legacy = determine_kprobe_perf_type() < 0;
@@ -11875,7 +11883,7 @@ bpf_program__attach_kprobe_opts(const struct bpf_program *prog,
 			return libbpf_err_ptr(-ENOMEM);
 
 		pfd = perf_event_kprobe_open_legacy(legacy_probe, retprobe, func_name,
-						    offset, -1 /* pid */);
+						    offset, -1 /* pid */, maxactive);
 	}
 	if (pfd < 0) {
 		err = pfd;

--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -563,10 +563,17 @@ struct bpf_kprobe_opts {
 	bool retprobe;
 	/* kprobe attach mode */
 	enum probe_attach_mode attach_mode;
+
+	/*
+	 * max number of instances of kretprobe that can be active at
+	 * one time; only applicable to legacy kprobes (0 = kernel default)
+	 */
+	int maxactive;
+
 	size_t :0;
 };
 
-#define bpf_kprobe_opts__last_field attach_mode
+#define bpf_kprobe_opts__last_field maxactive
 
 /**
  * @brief **bpf_program__attach_kprobe()** attaches a BPF program to a


### PR DESCRIPTION

### Description

This PR adds support for the `maxactive` parameter in legacy kprobe attach mode, allowing users to control the maximum number of concurrent kretprobe instances.

### Problem

When using kretprobes, the kernel allocates a fixed number of "instances" to track in-flight function calls. If the probed function is called more times concurrently than available instances, some calls will be missed without any notification.

Currently, libbpf's legacy kprobe path always uses the kernel default for `maxactive`, providing no way for users to tune this value for high-concurrency scenarios.

### Solution

Extend `struct bpf_kprobe_opts` with a new `maxactive` field and propagate it through the legacy kprobe attach path.

**Probe string format change:**

| Scenario | Probe String |
|----------|--------------|
| Before (or maxactive=0) | `r:kretprobes/libbpf_1638481_1___x64_sys_connect_0x0 __x64_sys_connect` |
| After (maxactive=32) | `r32:kretprobes/libbpf_1638481_1___x64_sys_connect_0x0 __x64_sys_connect` |

When `maxactive` is 0 (default), the original format is preserved, maintaining full backward compatibility.

### Changes

- `src/libbpf.h`: Added `maxactive` field to `struct bpf_kprobe_opts`
- `src/libbpf.c`: 
  - Updated `add_kprobe_event_legacy()` to accept and use `maxactive` parameter
  - Updated `perf_event_kprobe_open_legacy()` to pass `maxactive` through
  - Updated `bpf_program__attach_kprobe_opts()` to read `maxactive` from opts

### Usage Example

```c
LIBBPF_OPTS(bpf_kprobe_opts, opts,
    .retprobe = true,
    .attach_mode = PROBE_ATTACH_MODE_LEGACY,
    .maxactive = 32,
);

link = bpf_program__attach_kprobe_opts(prog, "func_name", &opts);
```

### Notes

- `maxactive` only applies to legacy kprobes (`PROBE_ATTACH_MODE_LEGACY`); it is ignored in modern perf-based attach modes
- Setting `maxactive = 0` uses the kernel default (typically `max(10, 2 * num_cpus)`)
- All modified internal functions are `static` — no ABI breakage

### Checklist

- [x] Code compiles without warnings
- [x] Backward compatible (default behavior unchanged)
- [x] No public API/ABI breakage
- [x] Internal functions remain static

### Related

Kernel documentation: https://www.kernel.org/doc/Documentation/trace/kprobetrace.txt
