### PR TITLE
Update LGPL 2.1 license text; switch to SPDX 3.0 identifier

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,1 @@
-LGPL-2.1 OR BSD-2-Clause
+LGPL-2.1-only OR BSD-2-Clause

--- a/LICENSE.LGPL-2.1-only
+++ b/LICENSE.LGPL-2.1-only
@@ -1,5 +1,7 @@
 Valid-License-Identifier: LGPL-2.1
+Valid-License-Identifier: LGPL-2.1-only
 Valid-License-Identifier: LGPL-2.1+
+Valid-License-Identifier: LGPL-2.1-or-later
 SPDX-URL: https://spdx.org/licenses/LGPL-2.1.html
 Usage-Guide:
   To use this license in source code, put one of the following SPDX
@@ -7,16 +9,20 @@ Usage-Guide:
   guidelines in the licensing rules documentation.
   For 'GNU Lesser General Public License (LGPL) version 2.1 only' use:
     SPDX-License-Identifier: LGPL-2.1
+  or:
+    SPDX-License-Identifier: LGPL-2.1-only
   For 'GNU Lesser General Public License (LGPL) version 2.1 or any later
   version' use:
     SPDX-License-Identifier: LGPL-2.1+
+  or:
+    SPDX-License-Identifier: LGPL-2.1-or-later
 License-Text:
 
 GNU LESSER GENERAL PUBLIC LICENSE
 Version 2.1, February 1999
 
 Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+<https://fsf.org/>
 
 Everyone is permitted to copy and distribute verbatim copies of this
 license document, but changing it is not allowed.
@@ -486,9 +492,9 @@ FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
 for more details.
 
 You should have received a copy of the GNU Lesser General Public License
-along with this library; if not, write to the Free Software Foundation,
-Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Also add
-information on how to contact you by electronic and paper mail.
+along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
 
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the library, if


### PR DESCRIPTION
This was copied over from the Linux kernel's LICENSES/preferred/LGPL-2.1 a long time ago, and did not have the newer SPDX 3.0 identifiers (where LGPL-2.1 is deprecated in favor of LGPL-2.1-only) and has the old FSF address listed (FSF has gone remote only:
https://www.fsf.org/about/contact/)

Copy in the new text from commit 89373f5695dc918a0118fa71ee4dc423bc8c8476 and refer to it using the new LGPL-2.1-only identifier

The source code itself needs to be modified in the Linux kernel tree, that will be done separate from this but fixing the files here first will make it easier for downstream packagers of libbpf